### PR TITLE
Qdfix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2021/10/29    Nakata Maho <maho@riken.jp> 1.0.1
+            * Add -fp-model precise to fix qd and dd arithmetic for Intel one API.
+
 2021/10/01    Nakata Maho <maho@riken.jp> 1.0.0
             * Release 1.0.0
 

--- a/Dockerfile_CentOS7
+++ b/Dockerfile_CentOS7
@@ -26,7 +26,7 @@ RUN echo "[user]" >> /home/$DOCKER_USER/.gitconfig && \
 
 RUN cd /home/$DOCKER_USER && echo "cd /home/$DOCKER_USER" >> .bashrc
 RUN cd /home/$DOCKER_USER && git clone https://github.com/nakatamaho/mplapack.git
-RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.0 && git log -1
+RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.1 && git log -1
 RUN cd /home/$DOCKER_USER/mplapack && bash -x misc/reconfig.centos7.sh
 RUN cd /home/$DOCKER_USER/mplapack && make -j`getconf _NPROCESSORS_ONLN`
 RUN cd /home/$DOCKER_USER/mplapack && make install

--- a/Dockerfile_CentOS7_AArch64
+++ b/Dockerfile_CentOS7_AArch64
@@ -26,7 +26,7 @@ RUN echo "[user]" >> /home/$DOCKER_USER/.gitconfig && \
 
 RUN cd /home/$DOCKER_USER && echo "cd /home/$DOCKER_USER" >> .bashrc
 RUN cd /home/$DOCKER_USER && git clone https://github.com/nakatamaho/mplapack.git
-RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.0 && git log -1
+RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.1 && git log -1
 RUN cd /home/$DOCKER_USER/mplapack && bash -x misc/reconfig.centos7.sh
 RUN cd /home/$DOCKER_USER/mplapack && make -j`getconf _NPROCESSORS_ONLN`
 RUN cd /home/$DOCKER_USER/mplapack && make install

--- a/Dockerfile_CentOS8
+++ b/Dockerfile_CentOS8
@@ -24,7 +24,7 @@ RUN echo "[user]" >> /home/$DOCKER_USER/.gitconfig && \
 
 RUN cd /home/$DOCKER_USER && echo "cd /home/$DOCKER_USER" >> .bashrc
 RUN cd /home/$DOCKER_USER && git clone https://github.com/nakatamaho/mplapack.git
-RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.0 && git log -1
+RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.1 && git log -1
 RUN cd /home/$DOCKER_USER/mplapack && bash -x misc/reconfig.centos8.sh
 RUN cd /home/$DOCKER_USER/mplapack && make -j`getconf _NPROCESSORS_ONLN`
 RUN cd /home/$DOCKER_USER/mplapack && make install

--- a/Dockerfile_debian_bullseye
+++ b/Dockerfile_debian_bullseye
@@ -34,7 +34,7 @@ RUN echo "\n\
 
 RUN cd /home/$DOCKER_USER && echo "cd /home/$DOCKER_USER" >> .bashrc
 RUN cd /home/$DOCKER_USER && git clone https://github.com/nakatamaho/mplapack.git
-RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.0 && git log -1
+RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.1 && git log -1
 RUN cd /home/$DOCKER_USER/mplapack && bash -x misc/reconfig.bullseye.sh
 RUN cd /home/$DOCKER_USER/mplapack && make -j`getconf _NPROCESSORS_ONLN`
 RUN cd /home/$DOCKER_USER/mplapack && make install

--- a/Dockerfile_ubuntu18.04
+++ b/Dockerfile_ubuntu18.04
@@ -34,7 +34,7 @@ RUN echo "\n\
 
 RUN cd /home/$DOCKER_USER && echo "cd /home/$DOCKER_USER" >> .bashrc
 RUN cd /home/$DOCKER_USER && git clone https://github.com/nakatamaho/mplapack.git
-RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.0 && git log -1
+RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.1 && git log -1
 RUN cd /home/$DOCKER_USER/mplapack && bash -x misc/reconfig.ubuntu18.04.sh
 RUN cd /home/$DOCKER_USER/mplapack && make -j`getconf _NPROCESSORS_ONLN`
 RUN cd /home/$DOCKER_USER/mplapack && make install

--- a/Dockerfile_ubuntu20.04
+++ b/Dockerfile_ubuntu20.04
@@ -34,7 +34,7 @@ RUN echo "\n\
 
 RUN cd /home/$DOCKER_USER && echo "cd /home/$DOCKER_USER" >> .bashrc
 RUN cd /home/$DOCKER_USER && git clone https://github.com/nakatamaho/mplapack.git
-RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.0 && git log -1
+RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.1 && git log -1
 RUN cd /home/$DOCKER_USER/mplapack && bash -x misc/reconfig.ubuntu20.04.sh
 RUN cd /home/$DOCKER_USER/mplapack && make -j`getconf _NPROCESSORS_ONLN`
 RUN cd /home/$DOCKER_USER/mplapack && make install

--- a/Dockerfile_ubuntu20.04_intel
+++ b/Dockerfile_ubuntu20.04_intel
@@ -41,7 +41,7 @@ RUN echo "\n\
 RUN cd /home/$DOCKER_USER && echo "cd /home/$DOCKER_USER" >> .bashrc
 RUN cd /home/$DOCKER_USER && echo "source /opt/intel/oneapi/setvars.sh" >> /home/$DOCKER_USER/.bashrc
 RUN cd /home/$DOCKER_USER && git clone https://github.com/nakatamaho/mplapack.git
-RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.0 && git log -1
+RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.1 && git log -1
 SHELL ["/bin/bash", "-c"]
 RUN cd /home/$DOCKER_USER/mplapack && source /opt/intel/oneapi/setvars.sh && bash -x misc/reconfig.ubuntu20.04.intel.sh
 RUN cd /home/$DOCKER_USER/mplapack && source /opt/intel/oneapi/setvars.sh && make -j`getconf _NPROCESSORS_ONLN`

--- a/Dockerfile_ubuntu20.04_mingw64
+++ b/Dockerfile_ubuntu20.04_mingw64
@@ -50,7 +50,7 @@ RUN cd /home/$DOCKER_USER && echo "cd /home/$DOCKER_USER" >> .bashrc
 RUN cd /home/$DOCKER_USER && echo "export WINEPATH=\"/usr/x86_64-w64-mingw32/lib/;/usr/lib/gcc/x86_64-w64-mingw32/9.3-win32/;/usr/lib/gcc/x86_64-w64-mingw32/9.3-posix;/home/docker/MPLAPACK/bin;/home/docker/MPLAPACK/lib\"" >> .bashrc
 ARG WINEPATH="/usr/x86_64-w64-mingw32/lib/;/usr/lib/gcc/x86_64-w64-mingw32/9.3-win32/;/usr/lib/gcc/x86_64-w64-mingw32/9.3-posix"
 RUN cd /home/$DOCKER_USER && git clone https://github.com/nakatamaho/mplapack.git
-RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.0 && git log -1
+RUN cd /home/$DOCKER_USER/mplapack && git checkout v1.0.1 && git log -1
 RUN cd /home/$DOCKER_USER/mplapack && bash -x misc/reconfig.ubuntu20.04.mingw64.sh
 RUN cd /home/$DOCKER_USER/mplapack && make -j`getconf _NPROCESSORS_ONLN`
 RUN cd /home/$DOCKER_USER/mplapack && make install

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ original license by LAPACK).
 
 # Capabilities
 * MPBLAS: All BLAS routines can be done in multiple precision arithmetic.
-* MPLAPACK: in ver 1.0.0 all Real version of following solvers (complex version will be added in 2.0)
+* MPLAPACK: in ver 1.0.1 all Real version of following solvers (complex version will be added in 2.0)
 * Linear Equations
 * Linear Least Squares (LLS) Problems
 * Generalized Linear Least Squares (LSE and GLM) Problems
@@ -56,7 +56,7 @@ Ubuntu 20.04 (amd64, AArch64)
 ```
 $ git clone https://github.com/nakatamaho/mplapack/
 $ cd mplapack
-$ git checokut v1.0.0
+$ git checokut v1.0.1
 $ /usr/bin/time docker build -t mplapack:ubuntu2004 -f Dockerfile_ubuntu20.04 . 2>&1 | tee log.ubuntu2004
 ```
 
@@ -64,7 +64,7 @@ CentOS 7 (amd64, AArch64)
 ```
 $ git clone https://github.com/nakatamaho/mplapack/
 $ cd mplapack
-$ git checokut v1.0.0
+$ git checokut v1.0.1
 $ /usr/bin/time docker build -t mplapack:centos7 -f Dockerfile_CentOS7 . 2>&1 | tee log.CentOS7
 ```
 
@@ -72,7 +72,7 @@ CentOS 8 (amd64, AArch64)
 ```
 $ git clone https://github.com/nakatamaho/mplapack/
 $ cd mplapack
-$ git checokut v1.0.0
+$ git checokut v1.0.1
 $ /usr/bin/time docker build -t mplapack:centos8 -f Dockerfile_CentOS8 . 2>&1 | tee log.CentOS8
 ```
 
@@ -80,7 +80,7 @@ Ubuntu 18.04 (amd64, AArch64)
 ```
 $ git clone https://github.com/nakatamaho/mplapack/
 $ cd mplapack
-$ git checokut v1.0.0
+$ git checokut v1.0.1
 $ /usr/bin/time docker build -t mplapack:ubuntu1804 -f Dockerfile_ubuntu18.04 . 2>&1 | tee log.ubuntu1804
 ```
 
@@ -88,7 +88,7 @@ Ubuntu 20.04 (using Intel oneAPI)
 ```
 $ git clone https://github.com/nakatamaho/mplapack/
 $ cd mplapack
-$ git checokut v1.0.0
+$ git checokut v1.0.1
 $ /usr/bin/time docker build -t mplapack:ubuntu2004intel -f Dockerfile_ubuntu20.04_intel . 2>&1 | tee log.ubuntu2004.intel
 ```
 
@@ -96,7 +96,7 @@ Windows 64bit (using cross compiler on Ubuntu)
 ```
 $ git clone https://github.com/nakatamaho/mplapack/
 $ cd mplapack
-$ git checokut v1.0.0
+$ git checokut v1.0.1
 $ /usr/bin/time docker build -t mplapack:mingw -f  Dockerfile_ubuntu20.04_mingw64 . 2>&1 | tee log.mingw
 ```
 
@@ -106,7 +106,7 @@ $ /usr/bin/time docker build -t mplapack:mingw -f  Dockerfile_ubuntu20.04_mingw6
 $ sudo port install gcc9 coreutils git ccache
 $ git clone https://github.com/nakatamaho/mplapack.git --depth 1
 $ cd mplapack
-$ git checokut v1.0.0
+$ git checokut v1.0.1
 $ pushd mplapack/debug ; bash gen.Makefile.am.sh ; popd
 $ autoreconf --force --install ; aclocal ; autoconf ; automake; autoreconf --force --install
 $ CXX="g++-mp-9" ; export CXX
@@ -169,6 +169,7 @@ This is the release schedule for MPLAPACK 3.0.0
 * version 1.0.0 https://github.com/nakatamaho/mplapack/blob/master/doc/Release1.0.0.md
 
 # History
+* 2021/11/1 1.0.1 release. Fixing dd and qd aritmetic by Inte One API.
 * 2021/10/1 1.0.0 release. Huge improvement; all real LAPACK routines are available; SVD, eigenproblem solver for non symmetric matrices are added. manual is available:  https://raw.githubusercontent.com/nakatamaho/mplapack/master/doc/manual/manual.pdf 
 * 2021/4/11 0.9.3 release. CentOS7 AArch64 support
 * 2021/4/6  0.9.1 release. CentOS support

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl
 
 m4_define([MPLAPACK_VER_MAJOR], [1])
 m4_define([MPLAPACK_VER_MINOR], [0])
-m4_define([MPLAPACK_VER_PATCH], [0])
+m4_define([MPLAPACK_VER_PATCH], [1])
 m4_define([MPLAPACK_VERSION], [MPLAPACK_VER_MAJOR.MPLAPACK_VER_MINOR.MPLAPACK_VER_PATCH])
 AC_INIT(mplapack, [MPLAPACK_VERSION])
 
@@ -31,7 +31,6 @@ AC_CONFIG_FILES([packaging/PKGBUILD packaging/mplapack.spec])
 AC_CANONICAL_TARGET
 
 AC_PROG_CC
-AC_PROG_CXX
 IS_INTELCC=0
 AC_COMPILE_IFELSE([
     AC_LANG_SOURCE([[
@@ -45,6 +44,27 @@ AC_COMPILE_IFELSE([
    ]]) 
 ], [is_intelcc=1])
 AM_CONDITIONAL(IS_INTELCC, test x$is_intelcc = x1)
+if test x"$is_intelcc" = x"1"; then
+    AC_MSG_RESULT([Intel One API (icc) detected])
+fi
+
+AC_PROG_CXX
+IS_INTELCXX=0
+AC_COMPILE_IFELSE([
+    AC_LANG_SOURCE([[
+    #if !defined __INTEL_COMPILER
+    #error
+    #endif
+    #include <stdio.h>
+    int main() {
+        return 0;    
+    }
+   ]]) 
+], [is_intelcxx=1])
+AM_CONDITIONAL(IS_INTELCXX, test x$is_intelcxx = x1)
+if test x"$is_intelcxx" = x"1"; then
+    AC_MSG_RESULT([Intel One API (icpc) detected])
+fi
 
 AC_PROG_LIBTOOL
 AM_INIT_AUTOMAKE([subdir-objects])
@@ -817,11 +837,20 @@ if test x"$enable_optimization" = x"yes" && test x"$enable_debug" = x"no" ; then
            FCFLAGS="$FCFLAGS -march=native -g -O2 -finline-functions -funroll-all-loops"
        ;;
     esac
-    if test x"is_intelcc" = x"1"; then
+    if test x"$is_intelcxx" = x"1"; then
         CXXFLAGS="$CXXFLAGS -xHost -O3"
-        CFLAGS="$CFLAGS -xHost -O3"
-        FCFLAGS="$FCFLAGS -xHost -O3"
     fi
+    if test x"$is_intelcc" = x"1"; then
+        CFLAGS="$CFLAGS -xHost -O3"
+    fi
+fi
+
+if test x"$is_intelcc" = x"1"; then
+    CFLAGS="$CFLAGS -fp-model precise"
+fi
+
+if test x"$is_intelcxx" = x"1"; then
+    CXXFLAGS="$CXXFLAGS -fp-model precise"
 fi
 
 AC_SUBST(CFLAGS)

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -132,7 +132,7 @@ Only 64 bit CPU is supported. Following OSes are supported:
 We support the following compilers:
 \begin{itemize}
 \item GCC (GNU Compiler Collection) 9 and 10
-\item Intel OneAPI.
+\item Intel One API. (you need {\tt -fp-model precise} for dd and qd)
 \end{itemize}
 Note that we use GCC by MacPorts on macOS, which is NOT the default compiler. We use the mingw64 and Wine64 environments on Linux to build and test the Windows version. On different configurations, MPLAPACK may build and work without problems. We welcome patches from the community.
 

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -68,7 +68,7 @@
 
 \begin{document}
   
-  \title{\sf MPLAPACK version 1.0.0 user manual}
+  \title{\sf MPLAPACK version 1.0.1 user manual}
   \author{NAKATA Maho$^1$\\
   \normalsize
   $^1$RIKEN Cluster for Pioneering Research, 2-1 Hirosawa, Wako-City, Saitama 351-0198, JAPAN}
@@ -80,8 +80,8 @@
 \begin{abstract}
 The MPLAPACK (formerly MPACK) is a multiple-precision version of LAPACK \\
 (\url{https://www.netlib.org/lapack/}).
-MPLAPACK version 1.0.0 is based on LAPACK version 3.9.1 and translated from Fortran 90 to C++ using FABLE, a Fortran to C++ source-to-source conversion tool (\url{https://github.com/cctbx/cctbx\_project/tree/master/fable/}). 
-MPLAPACK version 1.0.0 provides the real and complex version of MPBLAS, and the real version of MPLAPACK supports all LAPACK features: solvers for systems of simultaneous linear equations, least-squares solutions of linear systems of equations, eigenvalue problems, and singular value problems, and related matrix factorizations except for rectangular complete packed matrix form and mixed-precision routines. Besides, MPLAPACK supports a part of the complex routines of LAPACK, such as diagonalization of Hermite matrices, Cholesky factorization, and matrix inversion. The MPLAPACK defines an API for numerical linear algebra, similar to LAPACK. It is easy to port legacy C/C++ numerical codes using MPLAPACK. MPLAPACK supports binary64, binary128, FP80 (extended double), MPFR, GMP, and QD libraries (double-double and quad-double). Users can choose MPFR or GMP for arbitrary accurate calculations, double-double or quad-double for fast 32 or 64 decimal calculations. We can consider the binary64 version as the C++ version of LAPACK. MPLAPACK is available at GitHub (\url{https://github.com/nakatamaho/mplapack/}) under the 2-clause BSD license.
+MPLAPACK version 1.0.1 is based on LAPACK version 3.9.1 and translated from Fortran 90 to C++ using FABLE, a Fortran to C++ source-to-source conversion tool (\url{https://github.com/cctbx/cctbx\_project/tree/master/fable/}). 
+MPLAPACK version 1.0.1 provides the real and complex version of MPBLAS, and the real version of MPLAPACK supports all LAPACK features: solvers for systems of simultaneous linear equations, least-squares solutions of linear systems of equations, eigenvalue problems, and singular value problems, and related matrix factorizations except for rectangular complete packed matrix form and mixed-precision routines. Besides, MPLAPACK supports a part of the complex routines of LAPACK, such as diagonalization of Hermite matrices, Cholesky factorization, and matrix inversion. The MPLAPACK defines an API for numerical linear algebra, similar to LAPACK. It is easy to port legacy C/C++ numerical codes using MPLAPACK. MPLAPACK supports binary64, binary128, FP80 (extended double), MPFR, GMP, and QD libraries (double-double and quad-double). Users can choose MPFR or GMP for arbitrary accurate calculations, double-double or quad-double for fast 32 or 64 decimal calculations. We can consider the binary64 version as the C++ version of LAPACK. MPLAPACK is available at GitHub (\url{https://github.com/nakatamaho/mplapack/}) under the 2-clause BSD license.
 \end{abstract}
 
 \section{Introduction}
@@ -104,8 +104,8 @@ The features of MPLAPACK are:
 \item Completely rewrote LAPACK and BLAS in C++ using FABLE and f2c.
 \item C style programming. We do not introduce new matrix and vector classes. 
 \item Supports seven floating-point formats by precision independent programming; binary64 (16 decimal digits), binary128 (32 decimal digits), FP80 (extended double; 19 decimal digits), double-double (32 decimal digits), quad-double (64 decimal digits), GMP, and MPFR (arbitrary precision, and the default is 153 decimal digits).
-\item MPLAPACK 1.0.0 is based on LAPACK 3.9.1.
-\item Version 1.0.0 supports all real and complex versions of BLAS and real version LAPACK functions; simultaneous linear equations, least-squares solutions of linear systems of equations, eigenvalue problems, and singular value problems and related matrix factorization except for mixed-precision version, and full packed matrix form version and complex version will be supported in version 2.0.
+\item MPLAPACK 1.0.1 is based on LAPACK 3.9.1.
+\item Version 1.0.1 supports all real and complex versions of BLAS and real version LAPACK functions; simultaneous linear equations, least-squares solutions of linear systems of equations, eigenvalue problems, and singular value problems and related matrix factorization except for mixed-precision version, and full packed matrix form version and complex version will be supported in version 2.0.
 \item Reliability: We extended the original test programs to handle multiple-precision numbers, and most of the MPLAPCK routines have passed the test.
 \item Runs on Linux/Windows/Mac.
 \item Released at \url{https://github.com/nakatamaho/mplapack/} under 2-BSD clause license. 
@@ -145,7 +145,7 @@ For example, the following command will build inside docker on Ubuntu amd64 (als
 \begin{verbatim}
 $ git clone https://github.com/nakatamaho/mplapack/
 $ cd mplapack
-$ git checkout v1.0.0
+$ git checkout v1.0.1
 $ /usr/bin/time docker build -t mplapack:ubuntu2004 -f Dockerfile_ubuntu20.04 . \
    2>&1 | tee log.ubuntu2004
 \end{verbatim}
@@ -191,7 +191,7 @@ We list prerequisites for compiling from the source in Table~\ref{prerequisites}
 $ sudo port install gcc9 coreutils git ccache
 $ git clone https://github.com/nakatamaho/mplapack.git --depth 1
 $ cd mplapack
-$ git checkout v1.0.0
+$ git checkout v1.0.1
 $ pushd mplapack/debug ; bash gen.Makefile.am.sh ; popd
 $ autoreconf --force --install ; aclocal ; autoconf ; automake
 $ autoreconf --force --install
@@ -241,7 +241,7 @@ GMP~\cite{Granlund12} is a C library for arbitrary precision arithmetic, operati
 
 MPFR~\cite{10.1145/1236463.1236468} is a C library for multiple-precision floating-point computations with correct rounding based on GMP. We support complex numbers using MPC, which is a library for multiple-precision complex arithmetic with correct rounding~\cite{MPC} via ${\tt mpcomplex}$ class. Both libraries provide almost the same functionalities, but MPFR and MPC further support trigonometric functions necessary for cosine-sine decomposition, elementary and special functions. Therefore, we will drop GMP support in the future.
 
-{\tt long double} is no longer supported in MPLAPACK since v1.0.0 since the situation regarding {\tt long double} is very different and confusing in different environments. E.g., on Intel CPUs, {\tt long double} may be equivalent to {\tt \_Float64x}; however, it also depends on OSes. On Windows, {\tt long double} is equivalent to {\tt double}. Similar confusion happens in the AArch64 environment. ARM defines {\tt long double} should be binary64, but on the OS side, Apple overwrites {\tt long double} should be double. On IBM PowerPC or Power Macs, {\tt long double} have been double-double.
+{\tt long double} is no longer supported in MPLAPACK since v1.0.1 since the situation regarding {\tt long double} is very different and confusing in different environments. E.g., on Intel CPUs, {\tt long double} may be equivalent to {\tt \_Float64x}; however, it also depends on OSes. On Windows, {\tt long double} is equivalent to {\tt double}. Similar confusion happens in the AArch64 environment. ARM defines {\tt long double} should be binary64, but on the OS side, Apple overwrites {\tt long double} should be double. On IBM PowerPC or Power Macs, {\tt long double} have been double-double.
 
 \section{LAPACK and BLAS Routine Naming Conventions and available routines}
 \label{sec:nameconventions}
@@ -327,7 +327,7 @@ Raxpy & Rcopy & Rdot & Rgemm \\ \hline
 
 
 \begin{table}
-\caption{Available MPLAPACK Driver routines (1.0.0)}\label{mplapackdriver}
+\caption{Available MPLAPACK Driver routines (1.0.1)}\label{mplapackdriver}
 \begin{center}
 {\tt 
 \begin{tabular}{cccccccccc} \hline
@@ -343,7 +343,7 @@ Rsbgv & Rsbgv & Rsbgvx & Rgges  & Rggesx & Rggev & Rggevx & Rggsvd \\ \hline
 \end{table}
 
 \begin{table}
-\caption{Available MPLAPACK Computational Real routines (1.0.0)}\label{mplapackcomp}
+\caption{Available MPLAPACK Computational Real routines (1.0.1)}\label{mplapackcomp}
 \begin{center}
 {\tt
 \begin{tabular}{cccccccccccc} \hline
@@ -370,7 +370,7 @@ Rggsvp & Rtgsja \\
 \end{table}
 
 \begin{table}
-\caption{Available MPLAPACK Computational Complex routines (1.0.0)}\label{mplapackcomp_complex}
+\caption{Available MPLAPACK Computational Complex routines (1.0.1)}\label{mplapackcomp_complex}
 \begin{center}
 {\tt
 \begin{tabular}{cccccccccccc} \hline
@@ -2054,7 +2054,7 @@ We performed quality assurance of MPBLAS as follows.
 Since MPBLAS routines only consist of algebraic operations, this method ensures that all routines are correctly implemented. 
 
 \subsection{Testing MPLAPACK routines}
-Until version 0.9.4, we did the same method for quality assurance of MPLAPACK. From version 1.0.0, we ported {\tt lapack-3.9.1/TESTING/LIN} and {\tt lapack-3.9.1/TESTING/EIG} for all precisions using FABLE. The original test programs
+Until version 0.9.4, we did the same method for quality assurance of MPLAPACK. From version 1.0.1, we ported {\tt lapack-3.9.1/TESTING/LIN} and {\tt lapack-3.9.1/TESTING/EIG} for all precisions using FABLE. The original test programs
 use the {\tt FORMAT} statement extensively. Interestingly, FABLE and FABLE's Fortran EMulator library translate these {\tt FORMAT} statements almost perfectly except for printing out multiple-precision floating-point numbers. Thus our modifications to the testing routines were minimal. Furthermore, it took several months to pass all the tests for the {\tt MPFR} version.
 
 First, we review how to test LAPACK linear routines:
@@ -2116,7 +2116,7 @@ We test MPLAPACK routines for MPFR as follows:
 \begin{verbatim}
 $ cd /home/docker/mplapack/mplapack/test/lin/mpfr
 $ ./xlintstR_mpfr < ../Rtest.in
- Tests of the Multiple precision version of LAPACK MPLAPACK VERSION 1.0.0
+ Tests of the Multiple precision version of LAPACK MPLAPACK VERSION 1.0.1
  Based on the original LAPACK VERSION 3.9.1
 
 The following parameter values will be used:
@@ -2232,7 +2232,7 @@ We test MPLAPACK routines for MPFR as follows:
 $ cd /home/docker/mplapack/mplapack/test/eig/mpfr
 $ ./xeigtstR_mpfr < ../svd.in
  Tests of the Singular Value Decomposition routines
- Tests of the Multiple precision version of LAPACK MPLAPACK VERSION 1.0.0
+ Tests of the Multiple precision version of LAPACK MPLAPACK VERSION 1.0.1
  Based on original LAPACK VERSION 3.9.1
 
 The following parameter values will be used:
@@ -2285,7 +2285,7 @@ We simply use REAL, COMPLEX, INTEGER, LOGICAL, and BOOL to support all floating-
 
 The main differences between Fortran and C++ are: (i) array index starts from one, (ii) loop index may be incremented or decremented depending on its context, (iii) treatment of two-dimension arrays, (iv) when calling subroutines, the values are always referenced by FORTRAN, but we can choose call by value or call by reference in C++.  For (i), we use the same array index and decrements the index when accessing the array. (ii) we judge the direction of loop by hand, (iii) we expand two-dimension array using the leading dimension; we translate {\tt a(i,j)} to {\tt a[(i-1)  + (j-1) * lda]}, and (iv) we changed call by value when possible.
 
-In MPLAPACK 1.0.0, we used FABLE~\cite{fable} to convert all BLAS and LAPACK routines. In the original paper, they could translate {\tt dsyev.f} without modifications. However, the resultant source code also depends on Fortran Emulation Module (FEM), which is unnecessary for the MPBLAS and MPLAPACK parts, and the treatment of the array is a bit unnatural.  To make the resultant C++ code more natural and readable, we further patched {\tt cout.py} and passed through sed. Then, we modified the source codes by hand. For MPBLAS, conversion is almost automatic. For MPLAPACK, there are many hand-corrected minor syntax errors, interpretation of numbers, casts, and other corrections, but we can compile many of them without modifications. 
+In MPLAPACK 1.0.1, we used FABLE~\cite{fable} to convert all BLAS and LAPACK routines. In the original paper, they could translate {\tt dsyev.f} without modifications. However, the resultant source code also depends on Fortran Emulation Module (FEM), which is unnecessary for the MPBLAS and MPLAPACK parts, and the treatment of the array is a bit unnatural.  To make the resultant C++ code more natural and readable, we further patched {\tt cout.py} and passed through sed. Then, we modified the source codes by hand. For MPBLAS, conversion is almost automatic. For MPLAPACK, there are many hand-corrected minor syntax errors, interpretation of numbers, casts, and other corrections, but we can compile many of them without modifications. 
 
 More important part is translation of {\tt TESTING/LIN} and {\tt TESTING/EIG} from Fortran90 to C++. Thanks to FEM, the written statement of Fortran can be used  directly without modifications. According to ChangeLog, it took approximately three weeks to just compile programs in \\
 {\tt TESTING/LIN/xlint\{C,R\}\_mpfr} and {\tt TESTING/EIG/xeigtst\{C,R\}\_mpfr} for MPFR, although through check the results are required, and it took four months for real version and still ongoing for complex version.

--- a/mplapack/reference/iMlaver.cpp
+++ b/mplapack/reference/iMlaver.cpp
@@ -32,7 +32,7 @@
 void iMlaver(INTEGER &mplapack_ver_major, INTEGER &mplapack_ver_minor, INTEGER &mplapack_ver_patch, INTEGER &lapack_ver_major, INTEGER &lapack_ver_minor, INTEGER &lapack_ver_patch) {
     mplapack_ver_major = 1;
     mplapack_ver_minor = 0;
-    mplapack_ver_patch = 0;
+    mplapack_ver_patch = 1;
     lapack_ver_major = 3;
     lapack_ver_minor = 9;
     lapack_ver_patch = 1;


### PR DESCRIPTION
fix for dd and qd using intel one API. icc and icpc require "-fp-model precise" when comple.