### PR TITLE
fix multiplication assignment operator of mpcomplex

### DIFF
--- a/mpfrc++/mpcomplex.h
+++ b/mpfrc++/mpcomplex.h
@@ -706,7 +706,7 @@ inline mpcomplex &mpcomplex::operator*=(const mpfr_t a) {
 
 inline mpcomplex &mpcomplex::operator*=(const double a) {
     mpreal p(a);
-    mpc_add_fr(mpc, mpc, (mpfr_ptr)(&p), default_rnd);
+    mpc_mul_fr(mpc, mpc, (mpfr_ptr)(&p), default_rnd);
     return *this;
 }
 


### PR DESCRIPTION
Hi! I’ve encountered a bug in mpcomplex related to its multiplication assignment operator.