### PR TITLE
Fix git bootstrap (missing compare Makefile.am) and stale -std=gnu++11 override

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,19 @@ AC_CONFIG_FILES([ Makefile mplapack.pc ])
 AC_CONFIG_FILES([packaging/PKGBUILD packaging/mplapack.spec])
 
 AC_CANONICAL_TARGET
+
+dnl Determine the C++ compiler, then drop any -std=* that arrived through the
+dnl environment (CXX or CXXFLAGS) before selecting the required standard.
+dnl AX_CXX_COMPILE_STDCXX only *appends* -std=gnu++17 to CXX; it does not remove
+dnl a pre-existing -std.  A stale -std=gnu++11 (exported in CXX, or in CXXFLAGS
+dnl where it lands after CXX on the command line) would therefore survive and,
+dnl being last, override gnu++17 -- breaking the C++14/17 features the
+dnl mplapack_utils_*.h headers rely on (std::enable_if_t, std::is_same_v,
+dnl variadic fold expressions).  Strip first so exactly one -std=gnu++17 is in
+dnl effect and cannot be overridden.
+AC_PROG_CXX
+MPLAPACK_STRIP_FLAG([CXX], [-std=*])
+MPLAPACK_STRIP_FLAG([CXXFLAGS], [-std=*])
 AX_CXX_COMPILE_STDCXX([17], [ext], [mandatory])
 
 : ${CFLAGS=""}
@@ -117,7 +130,7 @@ AM_CONDITIONAL(IS_INTELCC, test x$is_intelcc = x1)
 if test x"$is_intelcc" = x"1"; then
     AC_MSG_RESULT([Intel compiler (icx/icpx) detected])
 fi
-AC_PROG_CXX
+dnl AC_PROG_CXX already run above (before the -std sanitisation).
 IS_INTELCXX=0
 AC_COMPILE_IFELSE([
     AC_LANG_SOURCE([[

--- a/mplapack/test/compare/Makefile.am
+++ b/mplapack/test/compare/Makefile.am
@@ -30,6 +30,20 @@ endif
 
 CHECK_SUBDIRS = $(SUBDIRS)
 
+# The per-backend Makefile.am files are committed (generated once via
+# gen.Makefile.am.sh from the *.part templates).  Ship the generator and its
+# templates so the test programs can be regenerated from a dist tarball after
+# new *.test.cpp cases are added under common/.
+EXTRA_DIST = \
+	gen.Makefile.am.sh \
+	gmp/Makefile.am.part \
+	mpfr/Makefile.am.part \
+	qd/Makefile.am.part \
+	dd/Makefile.am.part \
+	double/Makefile.am.part \
+	binary80/Makefile.am.part \
+	binary128/Makefile.am.part
+
 .PHONY: check-recursive $(CHECK_SUBDIRS:%=check-subdir-%)
 
 check-recursive: $(CHECK_SUBDIRS:%=check-subdir-%)

--- a/mplapack/test/compare/binary128/Makefile.am
+++ b/mplapack/test/compare/binary128/Makefile.am
@@ -1,0 +1,613 @@
+check_PROGRAMS = $(mplapack_binary128_test_PROGRAMS)
+TESTS = run_Rlaruv_test.sh run_Rlamch_test.sh
+CLEANFILES = run_Rlaruv_test.sh run_Rlamch_test.sh Rlaruv.txt Rlamch.txt
+
+TEST_EXTENSIONS = .sh
+SH_LOG_COMPILER = $(SHELL)
+
+AM_TESTS_ENVIRONMENT = \
+    LOG_COMPILER='$(LOG_COMPILER)'; export LOG_COMPILER; \
+    EXEEXT='$(EXEEXT)'; export EXEEXT; \
+    srcdir='$(srcdir)'; export srcdir;
+
+run_Rlaruv_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlaruv.test_binary128$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlaruv_reference.txt Rlaruv.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlaruv"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlaruv"; diff $${srcdir}/Rlaruv_reference.txt Rlaruv.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+run_Rlamch_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlamch.test_binary128$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlamch_reference.txt Rlamch.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlamch"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlamch"; diff $${srcdir}/Rlamch_reference.txt Rlamch.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+EXTRA_DIST = Rlaruv_reference.txt Rlamch_reference.txt
+
+.PHONY: check-all
+check-all: $(check_PROGRAMS)
+	$(MAKE) $(AM_MAKEFLAGS) check TESTS="$(mplapack_binary128_test_PROGRAMS)"
+
+mplapack_binary128_test_PROGRAMS = \
+Cgelq2.test_binary128 \
+Cgeqr2.test_binary128 \
+Cgeqrf.test_binary128 \
+Cgesv.test_binary128 \
+Cgetf2.test_binary128 \
+Cgetrf.test_binary128 \
+Cgetri.test_binary128 \
+Cgetrs.test_binary128 \
+Cheev.test_binary128 \
+Chetd2.test_binary128 \
+Chetrd.test_binary128 \
+Clacgv.test_binary128 \
+Clacrm.test_binary128 \
+Clacrt.test_binary128 \
+Cladiv.test_binary128 \
+Claesy.test_binary128 \
+Claev2.test_binary128 \
+Clahef.test_binary128 \
+Clanhe.test_binary128 \
+Clanht.test_binary128 \
+Clansy.test_binary128 \
+Clarfb.test_binary128 \
+Clarfg.test_binary128 \
+Clarf.test_binary128 \
+Clarft.test_binary128 \
+Clartg.test_binary128 \
+Clascl.test_binary128 \
+Claset.test_binary128 \
+Clasr.test_binary128 \
+Classq.test_binary128 \
+Claswp.test_binary128 \
+Clasyf.test_binary128 \
+Clatrd.test_binary128 \
+Cpotf2.test_binary128 \
+Crot.test_binary128 \
+Cspmv.test_binary128 \
+Cspr.test_binary128 \
+Csteqr.test_binary128 \
+Csymv.test_binary128 \
+Csyr.test_binary128 \
+Ctrti2.test_binary128 \
+Ctrtri.test_binary128 \
+Ctrtrs.test_binary128 \
+Cung2l.test_binary128 \
+Cung2r.test_binary128 \
+Cungql.test_binary128 \
+Cungqr.test_binary128 \
+Cungtr.test_binary128 \
+Cunmqr.test_binary128 \
+iCmax1.test_binary128 \
+iMlaenv.test_binary128 \
+Mlsamen.test_binary128 \
+Mutils.test_binary128 \
+RCsum1.test_binary128 \
+Rgecon.test_binary128 \
+Rgeequ.test_binary128 \
+Rgeqlf.test_binary128 \
+Rgesv.test_binary128 \
+Rgetf2.test_binary128 \
+Rgetrf.test_binary128 \
+Rgetri.test_binary128 \
+Rgetrs.test_binary128 \
+Rladiv.test_binary128 \
+Rlae2.test_binary128 \
+Rlaev2.test_binary128 \
+Rlamch.test_binary128 \
+Rlange.test_binary128 \
+Rlanst.test_binary128 \
+Rlansy.test_binary128 \
+Rlapy2.test_binary128 \
+Rlapy3.test_binary128 \
+Rlarfb.test_binary128 \
+Rlarfg.test_binary128 \
+Rlarf.test_binary128 \
+Rlarft.test_binary128 \
+Rlartg.test_binary128 \
+Rlaruv.test_binary128 \
+Rlascl.test_binary128 \
+Rlaset.test_binary128 \
+Rlasr.test_binary128 \
+Rlasrt.test_binary128 \
+Rlassq.test_binary128 \
+Rlaswp.test_binary128 \
+Rlasyf.test_binary128 \
+Rlatrd.test_binary128 \
+Rlatrs.test_binary128 \
+Rlauu2.test_binary128 \
+Rlauum.test_binary128 \
+Rnaninf.test_binary128 \
+Rorg2l.test_binary128 \
+Rorg2r.test_binary128 \
+Rorgql.test_binary128 \
+Rorgqr.test_binary128 \
+Rorgtr.test_binary128 \
+Rpocon.test_binary128 \
+Rposv.test_binary128 \
+Rpotf2.test_binary128 \
+Rpotri.test_binary128 \
+Rpotrs.test_binary128 \
+Rsteqr.test_binary128 \
+Rsterf.test_binary128 \
+Rsyev.test_binary128 \
+Rsytd2.test_binary128 \
+Rsytrd.test_binary128 \
+Rtrti2.test_binary128 \
+Rtrtri.test_binary128 \
+Rtrtrs.test_binary128 
+
+
+mplapack_binary128_testdir = $(prefix)/lib/$(target)/mplapack/test/compare/binary128
+
+install-data-hook:
+if IS_MACOS
+	bash $(top_srcdir)/misc/fix_dylib_macOS.sh $(mplapack_binary128_testdir) $(prefix)
+endif
+
+mplibs=-L$(MPC_LIBDIR) -L$(MPFR_LIBDIR) -lmpc -lmpfr -lgmpxx -lgmp
+refblas=-L$(top_builddir)/external/i/LAPACK/lib -lblas $(FCLIBS)
+reflapack=-L$(top_builddir)/external/i/LAPACK/lib -llapack $(FCLIBS)
+
+test_cxxflags = $(OPENMP_CXXFLAGS) -I$(top_srcdir)/include -I$(GMP_INCLUDEDIR) -I$(MPFR_INCLUDEDIR) -I$(MPC_INCLUDEDIR) -I$(top_srcdir)/mpfrc++ -D___MPLAPACK_BUILD_WITH_BINARY128___ -D___MPLAPACK_INTERNAL___
+AM_FFLAGS = -x f77-cpp-input -g
+
+test_srcdepends = ../../../../mpblas/test/common/xerbla.cpp ../../../../mpblas/test/common/mplapack.test.cpp
+
+if IS_MACOS
+mplibs+=-Wl,-flat_namespace,-undefined,dynamic_lookup
+endif
+
+if IS_MINGW
+$(check_PROGRAMS): libmxerbla_override.la
+lib_LTLIBRARIES = libmxerbla_override.la
+libmxerbla_override_la_CPPFLAGS = -I$(top_srcdir)/include -D___MPLAPACK_BUILD_WITH_BINARY128___
+libmxerbla_override_la_SOURCES = ../../../../mpblas/test/common/Mxerbla.override.cpp
+libmxerbla_override_la_LDFLAGS = -no-undefined
+
+test_libdepends = $(mplibs) $(reflapack) $(refblas) -Wl,--allow-multiple-definition
+libdepends = -Wl,--allow-multiple-definition -Wl,--whole-archive,.libs/libmxerbla_override.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_binary128.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_binary128.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_mpfr.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_mpfr.a,--no-whole-archive -lquadmath
+else
+test_srcdepends += ../../../../mpblas/test/common/Mxerbla.override.cpp
+test_libdepends = $(mplibs) $(reflapack) $(refblas)
+libdepends = -L$(top_builddir)/mplapack/reference -lmplapack_binary128 -lmplapack_mpfr -L$(top_builddir)/mpblas/reference -lmpblas_binary128 -lmpblas_mpfr
+endif
+
+Mutils_test_binary128_SOURCES  = ../common/Mutils.test.cpp $(test_srcdepends) ../common/ilaenv.cpp
+Mutils_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mutils_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cgelq2_test_binary128_SOURCES  = ../common/Cgelq2.test.cpp $(test_srcdepends)
+Cgelq2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgelq2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cgeqr2_test_binary128_SOURCES  = ../common/Cgeqr2.test.cpp $(test_srcdepends)
+Cgeqr2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqr2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cgeqrf_test_binary128_SOURCES  = ../common/Cgeqrf.test.cpp $(test_srcdepends)
+Cgeqrf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqrf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cgesv_test_binary128_SOURCES  = ../common/Cgesv.test.cpp $(test_srcdepends)
+Cgesv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgesv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cgetf2_test_binary128_SOURCES  = ../common/Cgetf2.test.cpp $(test_srcdepends)
+Cgetf2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetf2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cgetrf_test_binary128_SOURCES  = ../common/Cgetrf.test.cpp $(test_srcdepends)
+Cgetrf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cgetri_test_binary128_SOURCES  = ../common/Cgetri.test.cpp $(test_srcdepends)
+Cgetri_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetri_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cgetrs_test_binary128_SOURCES  = ../common/Cgetrs.test.cpp $(test_srcdepends)
+Cgetrs_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrs_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cheev_test_binary128_SOURCES  = ../common/Cheev.test.cpp $(test_srcdepends)
+Cheev_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cheev_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Chetd2_test_binary128_SOURCES  = ../common/Chetd2.test.cpp $(test_srcdepends)
+Chetd2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetd2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Chetrd_test_binary128_SOURCES  = ../common/Chetrd.test.cpp $(test_srcdepends)
+Chetrd_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetrd_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clacgv_test_binary128_SOURCES  = ../common/Clacgv.test.cpp $(test_srcdepends)
+Clacgv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacgv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clacrm_test_binary128_SOURCES  = ../common/Clacrm.test.cpp $(test_srcdepends)
+Clacrm_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrm_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clacrt_test_binary128_SOURCES  = ../common/Clacrt.test.cpp $(test_srcdepends)
+Clacrt_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrt_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cladiv_test_binary128_SOURCES  = ../common/Cladiv.test.cpp $(test_srcdepends)
+Cladiv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cladiv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Claesy_test_binary128_SOURCES  = ../common/Claesy.test.cpp $(test_srcdepends)
+Claesy_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claesy_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Claev2_test_binary128_SOURCES  = ../common/Claev2.test.cpp $(test_srcdepends)
+Claev2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claev2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clahef_test_binary128_SOURCES  = ../common/Clahef.test.cpp $(test_srcdepends)
+Clahef_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clahef_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clanhe_test_binary128_SOURCES  = ../common/Clanhe.test.cpp $(test_srcdepends)
+Clanhe_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanhe_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clanht_test_binary128_SOURCES  = ../common/Clanht.test.cpp $(test_srcdepends)
+Clanht_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanht_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clansy_test_binary128_SOURCES  = ../common/Clansy.test.cpp $(test_srcdepends)
+Clansy_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clansy_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clarfb_test_binary128_SOURCES  = ../common/Clarfb.test.cpp $(test_srcdepends)
+Clarfb_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfb_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clarfg_test_binary128_SOURCES  = ../common/Clarfg.test.cpp $(test_srcdepends)
+Clarfg_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfg_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clarf_test_binary128_SOURCES  = ../common/Clarf.test.cpp $(test_srcdepends)
+Clarf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clarft_test_binary128_SOURCES  = ../common/Clarft.test.cpp $(test_srcdepends)
+Clarft_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarft_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clartg_test_binary128_SOURCES  = ../common/Clartg.test.cpp $(test_srcdepends)
+Clartg_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clartg_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clascl_test_binary128_SOURCES  = ../common/Clascl.test.cpp $(test_srcdepends)
+Clascl_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clascl_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Claset_test_binary128_SOURCES  = ../common/Claset.test.cpp $(test_srcdepends)
+Claset_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claset_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clasr_test_binary128_SOURCES  = ../common/Clasr.test.cpp $(test_srcdepends)
+Clasr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Classq_test_binary128_SOURCES  = ../common/Classq.test.cpp $(test_srcdepends)
+Classq_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Classq_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Claswp_test_binary128_SOURCES  = ../common/Claswp.test.cpp $(test_srcdepends)
+Claswp_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claswp_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clasyf_test_binary128_SOURCES  = ../common/Clasyf.test.cpp $(test_srcdepends)
+Clasyf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasyf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Clatrd_test_binary128_SOURCES  = ../common/Clatrd.test.cpp $(test_srcdepends)
+Clatrd_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clatrd_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cpotf2_test_binary128_SOURCES  = ../common/Cpotf2.test.cpp $(test_srcdepends)
+Cpotf2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cpotf2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Crot_test_binary128_SOURCES  = ../common/Crot.test.cpp $(test_srcdepends)
+Crot_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Crot_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cspmv_test_binary128_SOURCES  = ../common/Cspmv.test.cpp $(test_srcdepends)
+Cspmv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspmv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cspr_test_binary128_SOURCES  = ../common/Cspr.test.cpp $(test_srcdepends)
+Cspr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Csteqr_test_binary128_SOURCES  = ../common/Csteqr.test.cpp $(test_srcdepends)
+Csteqr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csteqr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Csymv_test_binary128_SOURCES  = ../common/Csymv.test.cpp $(test_srcdepends)
+Csymv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csymv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Csyr_test_binary128_SOURCES  = ../common/Csyr.test.cpp $(test_srcdepends)
+Csyr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csyr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Ctrti2_test_binary128_SOURCES  = ../common/Ctrti2.test.cpp $(test_srcdepends)
+Ctrti2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrti2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Ctrtri_test_binary128_SOURCES  = ../common/Ctrtri.test.cpp $(test_srcdepends)
+Ctrtri_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtri_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Ctrtrs_test_binary128_SOURCES  = ../common/Ctrtrs.test.cpp $(test_srcdepends)
+Ctrtrs_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtrs_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cung2l_test_binary128_SOURCES  = ../common/Cung2l.test.cpp $(test_srcdepends)
+Cung2l_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2l_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cung2r_test_binary128_SOURCES  = ../common/Cung2r.test.cpp $(test_srcdepends)
+Cung2r_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2r_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cungql_test_binary128_SOURCES  = ../common/Cungql.test.cpp $(test_srcdepends)
+Cungql_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungql_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cungqr_test_binary128_SOURCES  = ../common/Cungqr.test.cpp $(test_srcdepends)
+Cungqr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungqr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cungtr_test_binary128_SOURCES  = ../common/Cungtr.test.cpp $(test_srcdepends)
+Cungtr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungtr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Cunmqr_test_binary128_SOURCES  = ../common/Cunmqr.test.cpp $(test_srcdepends)
+Cunmqr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cunmqr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+iCmax1_test_binary128_SOURCES  = ../common/iCmax1.test.cpp $(test_srcdepends)
+iCmax1_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+iCmax1_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+iMlaenv_test_binary128_SOURCES  = ../common/iMlaenv.test.cpp $(test_srcdepends)
+iMlaenv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+iMlaenv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Mlsamen_test_binary128_SOURCES  = ../common/Mlsamen.test.cpp $(test_srcdepends)
+Mlsamen_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mlsamen_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+RCsum1_test_binary128_SOURCES  = ../common/RCsum1.test.cpp $(test_srcdepends)
+RCsum1_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+RCsum1_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rgecon_test_binary128_SOURCES  = ../common/Rgecon.test.cpp $(test_srcdepends)
+Rgecon_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgecon_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rgeequ_test_binary128_SOURCES  = ../common/Rgeequ.test.cpp $(test_srcdepends)
+Rgeequ_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeequ_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rgeqlf_test_binary128_SOURCES  = ../common/Rgeqlf.test.cpp $(test_srcdepends)
+Rgeqlf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeqlf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rgesv_test_binary128_SOURCES  = ../common/Rgesv.test.cpp $(test_srcdepends)
+Rgesv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgesv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rgetf2_test_binary128_SOURCES  = ../common/Rgetf2.test.cpp $(test_srcdepends)
+Rgetf2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetf2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rgetrf_test_binary128_SOURCES  = ../common/Rgetrf.test.cpp $(test_srcdepends)
+Rgetrf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rgetri_test_binary128_SOURCES  = ../common/Rgetri.test.cpp $(test_srcdepends)
+Rgetri_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetri_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rgetrs_test_binary128_SOURCES  = ../common/Rgetrs.test.cpp $(test_srcdepends)
+Rgetrs_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrs_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rladiv_test_binary128_SOURCES  = ../common/Rladiv.test.cpp $(test_srcdepends)
+Rladiv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rladiv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlae2_test_binary128_SOURCES  = ../common/Rlae2.test.cpp $(test_srcdepends)
+Rlae2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlae2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlaev2_test_binary128_SOURCES  = ../common/Rlaev2.test.cpp $(test_srcdepends)
+Rlaev2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaev2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlamch_test_binary128_SOURCES  = ../common/Rlamch.test.cpp $(test_srcdepends)
+Rlamch_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlamch_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlange_test_binary128_SOURCES  = ../common/Rlange.test.cpp $(test_srcdepends)
+Rlange_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlange_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlanst_test_binary128_SOURCES  = ../common/Rlanst.test.cpp $(test_srcdepends)
+Rlanst_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlanst_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlansy_test_binary128_SOURCES  = ../common/Rlansy.test.cpp $(test_srcdepends)
+Rlansy_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlansy_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlapy2_test_binary128_SOURCES  = ../common/Rlapy2.test.cpp $(test_srcdepends)
+Rlapy2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlapy3_test_binary128_SOURCES  = ../common/Rlapy3.test.cpp $(test_srcdepends)
+Rlapy3_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy3_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlarfb_test_binary128_SOURCES  = ../common/Rlarfb.test.cpp $(test_srcdepends)
+Rlarfb_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfb_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlarfg_test_binary128_SOURCES  = ../common/Rlarfg.test.cpp $(test_srcdepends)
+Rlarfg_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfg_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlarf_test_binary128_SOURCES  = ../common/Rlarf.test.cpp $(test_srcdepends)
+Rlarf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlarft_test_binary128_SOURCES  = ../common/Rlarft.test.cpp $(test_srcdepends)
+Rlarft_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarft_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlartg_test_binary128_SOURCES  = ../common/Rlartg.test.cpp $(test_srcdepends)
+Rlartg_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlartg_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlaruv_test_binary128_SOURCES  = ../common/Rlaruv.test.cpp $(test_srcdepends)
+Rlaruv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaruv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlascl_test_binary128_SOURCES  = ../common/Rlascl.test.cpp $(test_srcdepends)
+Rlascl_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlascl_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlaset_test_binary128_SOURCES  = ../common/Rlaset.test.cpp $(test_srcdepends)
+Rlaset_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaset_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlasr_test_binary128_SOURCES  = ../common/Rlasr.test.cpp $(test_srcdepends)
+Rlasr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlasrt_test_binary128_SOURCES  = ../common/Rlasrt.test.cpp $(test_srcdepends)
+Rlasrt_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasrt_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlassq_test_binary128_SOURCES  = ../common/Rlassq.test.cpp $(test_srcdepends)
+Rlassq_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlassq_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlaswp_test_binary128_SOURCES  = ../common/Rlaswp.test.cpp $(test_srcdepends)
+Rlaswp_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaswp_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlasyf_test_binary128_SOURCES  = ../common/Rlasyf.test.cpp $(test_srcdepends)
+Rlasyf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasyf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlatrd_test_binary128_SOURCES  = ../common/Rlatrd.test.cpp $(test_srcdepends)
+Rlatrd_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrd_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlatrs_test_binary128_SOURCES  = ../common/Rlatrs.test.cpp $(test_srcdepends)
+Rlatrs_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrs_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlauu2_test_binary128_SOURCES  = ../common/Rlauu2.test.cpp $(test_srcdepends)
+Rlauu2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauu2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rlauum_test_binary128_SOURCES  = ../common/Rlauum.test.cpp $(test_srcdepends)
+Rlauum_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauum_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rnaninf_test_binary128_SOURCES  = ../common/Rnaninf.test.cpp $(test_srcdepends)
+Rnaninf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rnaninf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rorg2l_test_binary128_SOURCES  = ../common/Rorg2l.test.cpp $(test_srcdepends)
+Rorg2l_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2l_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rorg2r_test_binary128_SOURCES  = ../common/Rorg2r.test.cpp $(test_srcdepends)
+Rorg2r_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2r_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rorgql_test_binary128_SOURCES  = ../common/Rorgql.test.cpp $(test_srcdepends)
+Rorgql_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgql_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rorgqr_test_binary128_SOURCES  = ../common/Rorgqr.test.cpp $(test_srcdepends)
+Rorgqr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgqr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rorgtr_test_binary128_SOURCES  = ../common/Rorgtr.test.cpp $(test_srcdepends)
+Rorgtr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgtr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rpocon_test_binary128_SOURCES  = ../common/Rpocon.test.cpp $(test_srcdepends)
+Rpocon_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpocon_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rposv_test_binary128_SOURCES  = ../common/Rposv.test.cpp $(test_srcdepends)
+Rposv_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rposv_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rpotf2_test_binary128_SOURCES  = ../common/Rpotf2.test.cpp $(test_srcdepends)
+Rpotf2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotf2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rpotri_test_binary128_SOURCES  = ../common/Rpotri.test.cpp $(test_srcdepends)
+Rpotri_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotri_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rpotrs_test_binary128_SOURCES  = ../common/Rpotrs.test.cpp $(test_srcdepends)
+Rpotrs_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotrs_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rsteqr_test_binary128_SOURCES  = ../common/Rsteqr.test.cpp $(test_srcdepends)
+Rsteqr_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsteqr_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rsterf_test_binary128_SOURCES  = ../common/Rsterf.test.cpp $(test_srcdepends)
+Rsterf_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsterf_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rsyev_test_binary128_SOURCES  = ../common/Rsyev.test.cpp $(test_srcdepends)
+Rsyev_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsyev_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rsytd2_test_binary128_SOURCES  = ../common/Rsytd2.test.cpp $(test_srcdepends)
+Rsytd2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytd2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rsytrd_test_binary128_SOURCES  = ../common/Rsytrd.test.cpp $(test_srcdepends)
+Rsytrd_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytrd_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rtrti2_test_binary128_SOURCES  = ../common/Rtrti2.test.cpp $(test_srcdepends)
+Rtrti2_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrti2_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rtrtri_test_binary128_SOURCES  = ../common/Rtrtri.test.cpp $(test_srcdepends)
+Rtrtri_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtri_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+Rtrtrs_test_binary128_SOURCES  = ../common/Rtrtrs.test.cpp $(test_srcdepends)
+Rtrtrs_test_binary128_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtrs_test_binary128_CXXFLAGS = $(test_cxxflags)
+
+
+

--- a/mplapack/test/compare/binary80/Makefile.am
+++ b/mplapack/test/compare/binary80/Makefile.am
@@ -1,0 +1,613 @@
+check_PROGRAMS = $(mplapack_binary80_test_PROGRAMS)
+TESTS = run_Rlaruv_test.sh run_Rlamch_test.sh
+CLEANFILES = run_Rlaruv_test.sh run_Rlamch_test.sh Rlaruv.txt Rlamch.txt
+
+TEST_EXTENSIONS = .sh
+SH_LOG_COMPILER = $(SHELL)
+
+AM_TESTS_ENVIRONMENT = \
+    LOG_COMPILER='$(LOG_COMPILER)'; export LOG_COMPILER; \
+    EXEEXT='$(EXEEXT)'; export EXEEXT; \
+    srcdir='$(srcdir)'; export srcdir;
+
+run_Rlaruv_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlaruv.test_binary80$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlaruv_reference.txt Rlaruv.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlaruv"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlaruv"; diff $${srcdir}/Rlaruv_reference.txt Rlaruv.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+run_Rlamch_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlamch.test_binary80$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlamch_reference.txt Rlamch.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlamch"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlamch"; diff $${srcdir}/Rlamch_reference.txt Rlamch.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+EXTRA_DIST = Rlaruv_reference.txt Rlamch_reference.txt
+
+.PHONY: check-all
+check-all: $(check_PROGRAMS)
+	$(MAKE) $(AM_MAKEFLAGS) check TESTS="$(mplapack_binary80_test_PROGRAMS)"
+
+mplapack_binary80_test_PROGRAMS = \
+Cgelq2.test_binary80 \
+Cgeqr2.test_binary80 \
+Cgeqrf.test_binary80 \
+Cgesv.test_binary80 \
+Cgetf2.test_binary80 \
+Cgetrf.test_binary80 \
+Cgetri.test_binary80 \
+Cgetrs.test_binary80 \
+Cheev.test_binary80 \
+Chetd2.test_binary80 \
+Chetrd.test_binary80 \
+Clacgv.test_binary80 \
+Clacrm.test_binary80 \
+Clacrt.test_binary80 \
+Cladiv.test_binary80 \
+Claesy.test_binary80 \
+Claev2.test_binary80 \
+Clahef.test_binary80 \
+Clanhe.test_binary80 \
+Clanht.test_binary80 \
+Clansy.test_binary80 \
+Clarfb.test_binary80 \
+Clarfg.test_binary80 \
+Clarf.test_binary80 \
+Clarft.test_binary80 \
+Clartg.test_binary80 \
+Clascl.test_binary80 \
+Claset.test_binary80 \
+Clasr.test_binary80 \
+Classq.test_binary80 \
+Claswp.test_binary80 \
+Clasyf.test_binary80 \
+Clatrd.test_binary80 \
+Cpotf2.test_binary80 \
+Crot.test_binary80 \
+Cspmv.test_binary80 \
+Cspr.test_binary80 \
+Csteqr.test_binary80 \
+Csymv.test_binary80 \
+Csyr.test_binary80 \
+Ctrti2.test_binary80 \
+Ctrtri.test_binary80 \
+Ctrtrs.test_binary80 \
+Cung2l.test_binary80 \
+Cung2r.test_binary80 \
+Cungql.test_binary80 \
+Cungqr.test_binary80 \
+Cungtr.test_binary80 \
+Cunmqr.test_binary80 \
+iCmax1.test_binary80 \
+iMlaenv.test_binary80 \
+Mlsamen.test_binary80 \
+Mutils.test_binary80 \
+RCsum1.test_binary80 \
+Rgecon.test_binary80 \
+Rgeequ.test_binary80 \
+Rgeqlf.test_binary80 \
+Rgesv.test_binary80 \
+Rgetf2.test_binary80 \
+Rgetrf.test_binary80 \
+Rgetri.test_binary80 \
+Rgetrs.test_binary80 \
+Rladiv.test_binary80 \
+Rlae2.test_binary80 \
+Rlaev2.test_binary80 \
+Rlamch.test_binary80 \
+Rlange.test_binary80 \
+Rlanst.test_binary80 \
+Rlansy.test_binary80 \
+Rlapy2.test_binary80 \
+Rlapy3.test_binary80 \
+Rlarfb.test_binary80 \
+Rlarfg.test_binary80 \
+Rlarf.test_binary80 \
+Rlarft.test_binary80 \
+Rlartg.test_binary80 \
+Rlaruv.test_binary80 \
+Rlascl.test_binary80 \
+Rlaset.test_binary80 \
+Rlasr.test_binary80 \
+Rlasrt.test_binary80 \
+Rlassq.test_binary80 \
+Rlaswp.test_binary80 \
+Rlasyf.test_binary80 \
+Rlatrd.test_binary80 \
+Rlatrs.test_binary80 \
+Rlauu2.test_binary80 \
+Rlauum.test_binary80 \
+Rnaninf.test_binary80 \
+Rorg2l.test_binary80 \
+Rorg2r.test_binary80 \
+Rorgql.test_binary80 \
+Rorgqr.test_binary80 \
+Rorgtr.test_binary80 \
+Rpocon.test_binary80 \
+Rposv.test_binary80 \
+Rpotf2.test_binary80 \
+Rpotri.test_binary80 \
+Rpotrs.test_binary80 \
+Rsteqr.test_binary80 \
+Rsterf.test_binary80 \
+Rsyev.test_binary80 \
+Rsytd2.test_binary80 \
+Rsytrd.test_binary80 \
+Rtrti2.test_binary80 \
+Rtrtri.test_binary80 \
+Rtrtrs.test_binary80 
+
+
+mplapack_binary80_testdir = $(prefix)/lib/$(target)/mplapack/test/compare/binary80
+
+install-data-hook:
+if IS_MACOS
+	bash $(top_srcdir)/misc/fix_dylib_macOS.sh $(mplapack_binary80_testdir) $(prefix)
+endif
+
+mplibs=-L$(MPC_LIBDIR) -L$(MPFR_LIBDIR) -lmpc -lmpfr -lgmpxx -lgmp
+refblas=-L$(top_builddir)/external/i/LAPACK/lib -lblas $(FCLIBS)
+reflapack=-L$(top_builddir)/external/i/LAPACK/lib -llapack $(FCLIBS)
+
+test_cxxflags = $(OPENMP_CXXFLAGS) -I$(top_srcdir)/include -I$(GMP_INCLUDEDIR) -I$(MPFR_INCLUDEDIR) -I$(MPC_INCLUDEDIR) -I$(top_srcdir)/mpfrc++ -D___MPLAPACK_BUILD_WITH_BINARY80___ -D___MPLAPACK_INTERNAL___
+AM_FFLAGS = -x f77-cpp-input -g
+
+test_srcdepends = ../../../../mpblas/test/common/xerbla.cpp ../../../../mpblas/test/common/mplapack.test.cpp
+
+if IS_MACOS
+mplibs+=-Wl,-flat_namespace,-undefined,dynamic_lookup
+endif
+
+if IS_MINGW
+$(check_PROGRAMS): libmxerbla_override.la
+lib_LTLIBRARIES = libmxerbla_override.la
+libmxerbla_override_la_CPPFLAGS = -I$(top_srcdir)/include -D___MPLAPACK_BUILD_WITH_BINARY80___
+libmxerbla_override_la_SOURCES = ../../../../mpblas/test/common/Mxerbla.override.cpp
+libmxerbla_override_la_LDFLAGS = -no-undefined
+
+test_libdepends = $(mplibs) $(reflapack) $(refblas) -Wl,--allow-multiple-definition
+libdepends = -Wl,--allow-multiple-definition -Wl,--whole-archive,.libs/libmxerbla_override.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_binary80.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_binary80.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_mpfr.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_mpfr.a,--no-whole-archive
+else
+test_srcdepends += ../../../../mpblas/test/common/Mxerbla.override.cpp
+test_libdepends = $(mplibs) $(reflapack) $(refblas)
+libdepends = -L$(top_builddir)/mplapack/reference -lmplapack_binary80 -lmplapack_mpfr -L$(top_builddir)/mpblas/reference -lmpblas_binary80 -lmpblas_mpfr
+endif
+
+Mutils_test_binary80_SOURCES  = ../common/Mutils.test.cpp $(test_srcdepends) ../common/ilaenv.cpp
+Mutils_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mutils_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cgelq2_test_binary80_SOURCES  = ../common/Cgelq2.test.cpp $(test_srcdepends)
+Cgelq2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgelq2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cgeqr2_test_binary80_SOURCES  = ../common/Cgeqr2.test.cpp $(test_srcdepends)
+Cgeqr2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqr2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cgeqrf_test_binary80_SOURCES  = ../common/Cgeqrf.test.cpp $(test_srcdepends)
+Cgeqrf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqrf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cgesv_test_binary80_SOURCES  = ../common/Cgesv.test.cpp $(test_srcdepends)
+Cgesv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgesv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cgetf2_test_binary80_SOURCES  = ../common/Cgetf2.test.cpp $(test_srcdepends)
+Cgetf2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetf2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cgetrf_test_binary80_SOURCES  = ../common/Cgetrf.test.cpp $(test_srcdepends)
+Cgetrf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cgetri_test_binary80_SOURCES  = ../common/Cgetri.test.cpp $(test_srcdepends)
+Cgetri_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetri_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cgetrs_test_binary80_SOURCES  = ../common/Cgetrs.test.cpp $(test_srcdepends)
+Cgetrs_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrs_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cheev_test_binary80_SOURCES  = ../common/Cheev.test.cpp $(test_srcdepends)
+Cheev_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cheev_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Chetd2_test_binary80_SOURCES  = ../common/Chetd2.test.cpp $(test_srcdepends)
+Chetd2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetd2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Chetrd_test_binary80_SOURCES  = ../common/Chetrd.test.cpp $(test_srcdepends)
+Chetrd_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetrd_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clacgv_test_binary80_SOURCES  = ../common/Clacgv.test.cpp $(test_srcdepends)
+Clacgv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacgv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clacrm_test_binary80_SOURCES  = ../common/Clacrm.test.cpp $(test_srcdepends)
+Clacrm_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrm_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clacrt_test_binary80_SOURCES  = ../common/Clacrt.test.cpp $(test_srcdepends)
+Clacrt_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrt_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cladiv_test_binary80_SOURCES  = ../common/Cladiv.test.cpp $(test_srcdepends)
+Cladiv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cladiv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Claesy_test_binary80_SOURCES  = ../common/Claesy.test.cpp $(test_srcdepends)
+Claesy_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claesy_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Claev2_test_binary80_SOURCES  = ../common/Claev2.test.cpp $(test_srcdepends)
+Claev2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claev2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clahef_test_binary80_SOURCES  = ../common/Clahef.test.cpp $(test_srcdepends)
+Clahef_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clahef_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clanhe_test_binary80_SOURCES  = ../common/Clanhe.test.cpp $(test_srcdepends)
+Clanhe_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanhe_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clanht_test_binary80_SOURCES  = ../common/Clanht.test.cpp $(test_srcdepends)
+Clanht_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanht_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clansy_test_binary80_SOURCES  = ../common/Clansy.test.cpp $(test_srcdepends)
+Clansy_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clansy_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clarfb_test_binary80_SOURCES  = ../common/Clarfb.test.cpp $(test_srcdepends)
+Clarfb_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfb_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clarfg_test_binary80_SOURCES  = ../common/Clarfg.test.cpp $(test_srcdepends)
+Clarfg_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfg_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clarf_test_binary80_SOURCES  = ../common/Clarf.test.cpp $(test_srcdepends)
+Clarf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clarft_test_binary80_SOURCES  = ../common/Clarft.test.cpp $(test_srcdepends)
+Clarft_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarft_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clartg_test_binary80_SOURCES  = ../common/Clartg.test.cpp $(test_srcdepends)
+Clartg_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clartg_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clascl_test_binary80_SOURCES  = ../common/Clascl.test.cpp $(test_srcdepends)
+Clascl_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clascl_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Claset_test_binary80_SOURCES  = ../common/Claset.test.cpp $(test_srcdepends)
+Claset_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claset_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clasr_test_binary80_SOURCES  = ../common/Clasr.test.cpp $(test_srcdepends)
+Clasr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Classq_test_binary80_SOURCES  = ../common/Classq.test.cpp $(test_srcdepends)
+Classq_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Classq_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Claswp_test_binary80_SOURCES  = ../common/Claswp.test.cpp $(test_srcdepends)
+Claswp_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claswp_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clasyf_test_binary80_SOURCES  = ../common/Clasyf.test.cpp $(test_srcdepends)
+Clasyf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasyf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Clatrd_test_binary80_SOURCES  = ../common/Clatrd.test.cpp $(test_srcdepends)
+Clatrd_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clatrd_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cpotf2_test_binary80_SOURCES  = ../common/Cpotf2.test.cpp $(test_srcdepends)
+Cpotf2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cpotf2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Crot_test_binary80_SOURCES  = ../common/Crot.test.cpp $(test_srcdepends)
+Crot_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Crot_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cspmv_test_binary80_SOURCES  = ../common/Cspmv.test.cpp $(test_srcdepends)
+Cspmv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspmv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cspr_test_binary80_SOURCES  = ../common/Cspr.test.cpp $(test_srcdepends)
+Cspr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Csteqr_test_binary80_SOURCES  = ../common/Csteqr.test.cpp $(test_srcdepends)
+Csteqr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csteqr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Csymv_test_binary80_SOURCES  = ../common/Csymv.test.cpp $(test_srcdepends)
+Csymv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csymv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Csyr_test_binary80_SOURCES  = ../common/Csyr.test.cpp $(test_srcdepends)
+Csyr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csyr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Ctrti2_test_binary80_SOURCES  = ../common/Ctrti2.test.cpp $(test_srcdepends)
+Ctrti2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrti2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Ctrtri_test_binary80_SOURCES  = ../common/Ctrtri.test.cpp $(test_srcdepends)
+Ctrtri_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtri_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Ctrtrs_test_binary80_SOURCES  = ../common/Ctrtrs.test.cpp $(test_srcdepends)
+Ctrtrs_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtrs_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cung2l_test_binary80_SOURCES  = ../common/Cung2l.test.cpp $(test_srcdepends)
+Cung2l_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2l_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cung2r_test_binary80_SOURCES  = ../common/Cung2r.test.cpp $(test_srcdepends)
+Cung2r_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2r_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cungql_test_binary80_SOURCES  = ../common/Cungql.test.cpp $(test_srcdepends)
+Cungql_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungql_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cungqr_test_binary80_SOURCES  = ../common/Cungqr.test.cpp $(test_srcdepends)
+Cungqr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungqr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cungtr_test_binary80_SOURCES  = ../common/Cungtr.test.cpp $(test_srcdepends)
+Cungtr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungtr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Cunmqr_test_binary80_SOURCES  = ../common/Cunmqr.test.cpp $(test_srcdepends)
+Cunmqr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cunmqr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+iCmax1_test_binary80_SOURCES  = ../common/iCmax1.test.cpp $(test_srcdepends)
+iCmax1_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+iCmax1_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+iMlaenv_test_binary80_SOURCES  = ../common/iMlaenv.test.cpp $(test_srcdepends)
+iMlaenv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+iMlaenv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Mlsamen_test_binary80_SOURCES  = ../common/Mlsamen.test.cpp $(test_srcdepends)
+Mlsamen_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mlsamen_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+RCsum1_test_binary80_SOURCES  = ../common/RCsum1.test.cpp $(test_srcdepends)
+RCsum1_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+RCsum1_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rgecon_test_binary80_SOURCES  = ../common/Rgecon.test.cpp $(test_srcdepends)
+Rgecon_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgecon_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rgeequ_test_binary80_SOURCES  = ../common/Rgeequ.test.cpp $(test_srcdepends)
+Rgeequ_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeequ_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rgeqlf_test_binary80_SOURCES  = ../common/Rgeqlf.test.cpp $(test_srcdepends)
+Rgeqlf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeqlf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rgesv_test_binary80_SOURCES  = ../common/Rgesv.test.cpp $(test_srcdepends)
+Rgesv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgesv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rgetf2_test_binary80_SOURCES  = ../common/Rgetf2.test.cpp $(test_srcdepends)
+Rgetf2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetf2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rgetrf_test_binary80_SOURCES  = ../common/Rgetrf.test.cpp $(test_srcdepends)
+Rgetrf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rgetri_test_binary80_SOURCES  = ../common/Rgetri.test.cpp $(test_srcdepends)
+Rgetri_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetri_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rgetrs_test_binary80_SOURCES  = ../common/Rgetrs.test.cpp $(test_srcdepends)
+Rgetrs_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrs_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rladiv_test_binary80_SOURCES  = ../common/Rladiv.test.cpp $(test_srcdepends)
+Rladiv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rladiv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlae2_test_binary80_SOURCES  = ../common/Rlae2.test.cpp $(test_srcdepends)
+Rlae2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlae2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlaev2_test_binary80_SOURCES  = ../common/Rlaev2.test.cpp $(test_srcdepends)
+Rlaev2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaev2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlamch_test_binary80_SOURCES  = ../common/Rlamch.test.cpp $(test_srcdepends)
+Rlamch_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlamch_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlange_test_binary80_SOURCES  = ../common/Rlange.test.cpp $(test_srcdepends)
+Rlange_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlange_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlanst_test_binary80_SOURCES  = ../common/Rlanst.test.cpp $(test_srcdepends)
+Rlanst_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlanst_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlansy_test_binary80_SOURCES  = ../common/Rlansy.test.cpp $(test_srcdepends)
+Rlansy_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlansy_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlapy2_test_binary80_SOURCES  = ../common/Rlapy2.test.cpp $(test_srcdepends)
+Rlapy2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlapy3_test_binary80_SOURCES  = ../common/Rlapy3.test.cpp $(test_srcdepends)
+Rlapy3_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy3_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlarfb_test_binary80_SOURCES  = ../common/Rlarfb.test.cpp $(test_srcdepends)
+Rlarfb_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfb_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlarfg_test_binary80_SOURCES  = ../common/Rlarfg.test.cpp $(test_srcdepends)
+Rlarfg_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfg_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlarf_test_binary80_SOURCES  = ../common/Rlarf.test.cpp $(test_srcdepends)
+Rlarf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlarft_test_binary80_SOURCES  = ../common/Rlarft.test.cpp $(test_srcdepends)
+Rlarft_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarft_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlartg_test_binary80_SOURCES  = ../common/Rlartg.test.cpp $(test_srcdepends)
+Rlartg_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlartg_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlaruv_test_binary80_SOURCES  = ../common/Rlaruv.test.cpp $(test_srcdepends)
+Rlaruv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaruv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlascl_test_binary80_SOURCES  = ../common/Rlascl.test.cpp $(test_srcdepends)
+Rlascl_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlascl_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlaset_test_binary80_SOURCES  = ../common/Rlaset.test.cpp $(test_srcdepends)
+Rlaset_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaset_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlasr_test_binary80_SOURCES  = ../common/Rlasr.test.cpp $(test_srcdepends)
+Rlasr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlasrt_test_binary80_SOURCES  = ../common/Rlasrt.test.cpp $(test_srcdepends)
+Rlasrt_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasrt_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlassq_test_binary80_SOURCES  = ../common/Rlassq.test.cpp $(test_srcdepends)
+Rlassq_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlassq_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlaswp_test_binary80_SOURCES  = ../common/Rlaswp.test.cpp $(test_srcdepends)
+Rlaswp_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaswp_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlasyf_test_binary80_SOURCES  = ../common/Rlasyf.test.cpp $(test_srcdepends)
+Rlasyf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasyf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlatrd_test_binary80_SOURCES  = ../common/Rlatrd.test.cpp $(test_srcdepends)
+Rlatrd_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrd_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlatrs_test_binary80_SOURCES  = ../common/Rlatrs.test.cpp $(test_srcdepends)
+Rlatrs_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrs_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlauu2_test_binary80_SOURCES  = ../common/Rlauu2.test.cpp $(test_srcdepends)
+Rlauu2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauu2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rlauum_test_binary80_SOURCES  = ../common/Rlauum.test.cpp $(test_srcdepends)
+Rlauum_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauum_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rnaninf_test_binary80_SOURCES  = ../common/Rnaninf.test.cpp $(test_srcdepends)
+Rnaninf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rnaninf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rorg2l_test_binary80_SOURCES  = ../common/Rorg2l.test.cpp $(test_srcdepends)
+Rorg2l_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2l_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rorg2r_test_binary80_SOURCES  = ../common/Rorg2r.test.cpp $(test_srcdepends)
+Rorg2r_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2r_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rorgql_test_binary80_SOURCES  = ../common/Rorgql.test.cpp $(test_srcdepends)
+Rorgql_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgql_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rorgqr_test_binary80_SOURCES  = ../common/Rorgqr.test.cpp $(test_srcdepends)
+Rorgqr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgqr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rorgtr_test_binary80_SOURCES  = ../common/Rorgtr.test.cpp $(test_srcdepends)
+Rorgtr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgtr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rpocon_test_binary80_SOURCES  = ../common/Rpocon.test.cpp $(test_srcdepends)
+Rpocon_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpocon_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rposv_test_binary80_SOURCES  = ../common/Rposv.test.cpp $(test_srcdepends)
+Rposv_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rposv_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rpotf2_test_binary80_SOURCES  = ../common/Rpotf2.test.cpp $(test_srcdepends)
+Rpotf2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotf2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rpotri_test_binary80_SOURCES  = ../common/Rpotri.test.cpp $(test_srcdepends)
+Rpotri_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotri_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rpotrs_test_binary80_SOURCES  = ../common/Rpotrs.test.cpp $(test_srcdepends)
+Rpotrs_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotrs_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rsteqr_test_binary80_SOURCES  = ../common/Rsteqr.test.cpp $(test_srcdepends)
+Rsteqr_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsteqr_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rsterf_test_binary80_SOURCES  = ../common/Rsterf.test.cpp $(test_srcdepends)
+Rsterf_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsterf_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rsyev_test_binary80_SOURCES  = ../common/Rsyev.test.cpp $(test_srcdepends)
+Rsyev_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsyev_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rsytd2_test_binary80_SOURCES  = ../common/Rsytd2.test.cpp $(test_srcdepends)
+Rsytd2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytd2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rsytrd_test_binary80_SOURCES  = ../common/Rsytrd.test.cpp $(test_srcdepends)
+Rsytrd_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytrd_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rtrti2_test_binary80_SOURCES  = ../common/Rtrti2.test.cpp $(test_srcdepends)
+Rtrti2_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrti2_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rtrtri_test_binary80_SOURCES  = ../common/Rtrtri.test.cpp $(test_srcdepends)
+Rtrtri_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtri_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+Rtrtrs_test_binary80_SOURCES  = ../common/Rtrtrs.test.cpp $(test_srcdepends)
+Rtrtrs_test_binary80_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtrs_test_binary80_CXXFLAGS = $(test_cxxflags)
+
+
+

--- a/mplapack/test/compare/dd/Makefile.am
+++ b/mplapack/test/compare/dd/Makefile.am
@@ -1,0 +1,615 @@
+check_PROGRAMS = $(mplapack_dd_test_PROGRAMS)
+TESTS = run_Rlaruv_test.sh run_Rlamch_test.sh
+CLEANFILES = run_Rlaruv_test.sh run_Rlamch_test.sh Rlaruv.txt Rlamch.txt
+
+TEST_EXTENSIONS = .sh
+SH_LOG_COMPILER = $(SHELL)
+
+AM_TESTS_ENVIRONMENT = \
+    LOG_COMPILER='$(LOG_COMPILER)'; export LOG_COMPILER; \
+    EXEEXT='$(EXEEXT)'; export EXEEXT; \
+    srcdir='$(srcdir)'; export srcdir;
+
+run_Rlaruv_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo 'NUM_DIFF_PY="$(top_srcdir)/misc/num_diff.py"' >> $@
+	@echo '$${LOG_COMPILER} ./Rlaruv.test_dd$${EXEEXT} || true' >> $@
+	@echo 'if python3 "$${NUM_DIFF_PY}" "$${srcdir}/Rlaruv_reference.txt" Rlaruv.txt --tol 1e-30; then' >> $@
+	@echo '  echo "PASS: Rlaruv"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlaruv"; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+run_Rlamch_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo 'NUM_DIFF_PY="$(top_srcdir)/misc/num_diff.py"' >> $@
+	@echo '$${LOG_COMPILER} ./Rlamch.test_dd$${EXEEXT} || true' >> $@
+	@echo 'if python3 "$${NUM_DIFF_PY}" "$${srcdir}/Rlamch_reference.txt" Rlamch.txt --tol 1e-30; then' >> $@
+	@echo '  echo "PASS: Rlamch"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlamch"; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+EXTRA_DIST = Rlaruv_reference.txt Rlamch_reference.txt
+
+.PHONY: check-all
+check-all: $(check_PROGRAMS)
+	$(MAKE) $(AM_MAKEFLAGS) check TESTS="$(mplapack_dd_test_PROGRAMS)"
+
+mplapack_dd_test_PROGRAMS = \
+Cgelq2.test_dd \
+Cgeqr2.test_dd \
+Cgeqrf.test_dd \
+Cgesv.test_dd \
+Cgetf2.test_dd \
+Cgetrf.test_dd \
+Cgetri.test_dd \
+Cgetrs.test_dd \
+Cheev.test_dd \
+Chetd2.test_dd \
+Chetrd.test_dd \
+Clacgv.test_dd \
+Clacrm.test_dd \
+Clacrt.test_dd \
+Cladiv.test_dd \
+Claesy.test_dd \
+Claev2.test_dd \
+Clahef.test_dd \
+Clanhe.test_dd \
+Clanht.test_dd \
+Clansy.test_dd \
+Clarfb.test_dd \
+Clarfg.test_dd \
+Clarf.test_dd \
+Clarft.test_dd \
+Clartg.test_dd \
+Clascl.test_dd \
+Claset.test_dd \
+Clasr.test_dd \
+Classq.test_dd \
+Claswp.test_dd \
+Clasyf.test_dd \
+Clatrd.test_dd \
+Cpotf2.test_dd \
+Crot.test_dd \
+Cspmv.test_dd \
+Cspr.test_dd \
+Csteqr.test_dd \
+Csymv.test_dd \
+Csyr.test_dd \
+Ctrti2.test_dd \
+Ctrtri.test_dd \
+Ctrtrs.test_dd \
+Cung2l.test_dd \
+Cung2r.test_dd \
+Cungql.test_dd \
+Cungqr.test_dd \
+Cungtr.test_dd \
+Cunmqr.test_dd \
+iCmax1.test_dd \
+iMlaenv.test_dd \
+Mlsamen.test_dd \
+Mutils.test_dd \
+RCsum1.test_dd \
+Rgecon.test_dd \
+Rgeequ.test_dd \
+Rgeqlf.test_dd \
+Rgesv.test_dd \
+Rgetf2.test_dd \
+Rgetrf.test_dd \
+Rgetri.test_dd \
+Rgetrs.test_dd \
+Rladiv.test_dd \
+Rlae2.test_dd \
+Rlaev2.test_dd \
+Rlamch.test_dd \
+Rlange.test_dd \
+Rlanst.test_dd \
+Rlansy.test_dd \
+Rlapy2.test_dd \
+Rlapy3.test_dd \
+Rlarfb.test_dd \
+Rlarfg.test_dd \
+Rlarf.test_dd \
+Rlarft.test_dd \
+Rlartg.test_dd \
+Rlaruv.test_dd \
+Rlascl.test_dd \
+Rlaset.test_dd \
+Rlasr.test_dd \
+Rlasrt.test_dd \
+Rlassq.test_dd \
+Rlaswp.test_dd \
+Rlasyf.test_dd \
+Rlatrd.test_dd \
+Rlatrs.test_dd \
+Rlauu2.test_dd \
+Rlauum.test_dd \
+Rnaninf.test_dd \
+Rorg2l.test_dd \
+Rorg2r.test_dd \
+Rorgql.test_dd \
+Rorgqr.test_dd \
+Rorgtr.test_dd \
+Rpocon.test_dd \
+Rposv.test_dd \
+Rpotf2.test_dd \
+Rpotri.test_dd \
+Rpotrs.test_dd \
+Rsteqr.test_dd \
+Rsterf.test_dd \
+Rsyev.test_dd \
+Rsytd2.test_dd \
+Rsytrd.test_dd \
+Rtrti2.test_dd \
+Rtrtri.test_dd \
+Rtrtrs.test_dd 
+
+
+mplapack_dd_testdir = $(prefix)/lib/$(target)/mplapack/test/compare/dd
+
+install-data-hook:
+if IS_MACOS
+	bash $(top_srcdir)/misc/fix_dylib_macOS.sh $(mplapack_dd_testdir) $(prefix)
+endif
+
+mplibs=-L$(MPC_LIBDIR) -L$(MPFR_LIBDIR) -L$(QD_LIBDIR) -lmpc -lmpfr -lgmpxx -lgmp -lqd
+refblas=-L$(top_builddir)/external/i/LAPACK/lib -lblas $(FCLIBS)
+reflapack=-L$(top_builddir)/external/i/LAPACK/lib -llapack $(FCLIBS)
+
+test_cxxflags = $(OPENMP_CXXFLAGS) -I$(top_srcdir)/include -I$(GMP_INCLUDEDIR) -I$(MPFR_INCLUDEDIR) -I$(MPC_INCLUDEDIR) -I$(QD_INCLUDEDIR) -I$(top_srcdir)/mpfrc++ -D___MPLAPACK_BUILD_WITH_DD___ -D___MPLAPACK_INTERNAL___ $(DD_CXXFLAGS)
+AM_FFLAGS = -x f77-cpp-input -g
+
+test_srcdepends = ../../../../mpblas/test/common/xerbla.cpp ../../../../mpblas/test/common/mplapack.test.cpp
+
+if IS_MACOS
+mplibs+=-Wl,-flat_namespace,-undefined,dynamic_lookup
+endif
+
+if IS_MINGW
+$(check_PROGRAMS): libmxerbla_override.la
+lib_LTLIBRARIES = libmxerbla_override.la
+libmxerbla_override_la_CPPFLAGS = -I$(top_srcdir)/include -D___MPLAPACK_BUILD_WITH_DD___
+libmxerbla_override_la_SOURCES = ../../../../mpblas/test/common/Mxerbla.override.cpp
+libmxerbla_override_la_LDFLAGS = -no-undefined
+
+test_libdepends = $(mplibs) $(reflapack) $(refblas) -Wl,--allow-multiple-definition
+libdepends = -Wl,--allow-multiple-definition -Wl,--whole-archive,.libs/libmxerbla_override.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_dd.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_dd.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_mpfr.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_mpfr.a,--no-whole-archive
+else
+test_srcdepends += ../../../../mpblas/test/common/Mxerbla.override.cpp
+test_libdepends = $(mplibs) $(reflapack) $(refblas)
+libdepends = -L$(top_builddir)/mplapack/reference -lmplapack_dd -lmplapack_mpfr -L$(top_builddir)/mpblas/reference -lmpblas_dd -lmpblas_mpfr
+endif
+
+Mutils_test_dd_SOURCES  = ../common/Mutils.test.cpp $(test_srcdepends) ../common/ilaenv.cpp
+Mutils_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mutils_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cgelq2_test_dd_SOURCES  = ../common/Cgelq2.test.cpp $(test_srcdepends)
+Cgelq2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgelq2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cgeqr2_test_dd_SOURCES  = ../common/Cgeqr2.test.cpp $(test_srcdepends)
+Cgeqr2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqr2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cgeqrf_test_dd_SOURCES  = ../common/Cgeqrf.test.cpp $(test_srcdepends)
+Cgeqrf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqrf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cgesv_test_dd_SOURCES  = ../common/Cgesv.test.cpp $(test_srcdepends)
+Cgesv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgesv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cgetf2_test_dd_SOURCES  = ../common/Cgetf2.test.cpp $(test_srcdepends)
+Cgetf2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetf2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cgetrf_test_dd_SOURCES  = ../common/Cgetrf.test.cpp $(test_srcdepends)
+Cgetrf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cgetri_test_dd_SOURCES  = ../common/Cgetri.test.cpp $(test_srcdepends)
+Cgetri_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetri_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cgetrs_test_dd_SOURCES  = ../common/Cgetrs.test.cpp $(test_srcdepends)
+Cgetrs_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrs_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cheev_test_dd_SOURCES  = ../common/Cheev.test.cpp $(test_srcdepends)
+Cheev_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cheev_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Chetd2_test_dd_SOURCES  = ../common/Chetd2.test.cpp $(test_srcdepends)
+Chetd2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetd2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Chetrd_test_dd_SOURCES  = ../common/Chetrd.test.cpp $(test_srcdepends)
+Chetrd_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetrd_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clacgv_test_dd_SOURCES  = ../common/Clacgv.test.cpp $(test_srcdepends)
+Clacgv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacgv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clacrm_test_dd_SOURCES  = ../common/Clacrm.test.cpp $(test_srcdepends)
+Clacrm_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrm_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clacrt_test_dd_SOURCES  = ../common/Clacrt.test.cpp $(test_srcdepends)
+Clacrt_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrt_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cladiv_test_dd_SOURCES  = ../common/Cladiv.test.cpp $(test_srcdepends)
+Cladiv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cladiv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Claesy_test_dd_SOURCES  = ../common/Claesy.test.cpp $(test_srcdepends)
+Claesy_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claesy_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Claev2_test_dd_SOURCES  = ../common/Claev2.test.cpp $(test_srcdepends)
+Claev2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claev2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clahef_test_dd_SOURCES  = ../common/Clahef.test.cpp $(test_srcdepends)
+Clahef_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clahef_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clanhe_test_dd_SOURCES  = ../common/Clanhe.test.cpp $(test_srcdepends)
+Clanhe_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanhe_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clanht_test_dd_SOURCES  = ../common/Clanht.test.cpp $(test_srcdepends)
+Clanht_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanht_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clansy_test_dd_SOURCES  = ../common/Clansy.test.cpp $(test_srcdepends)
+Clansy_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clansy_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clarfb_test_dd_SOURCES  = ../common/Clarfb.test.cpp $(test_srcdepends)
+Clarfb_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfb_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clarfg_test_dd_SOURCES  = ../common/Clarfg.test.cpp $(test_srcdepends)
+Clarfg_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfg_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clarf_test_dd_SOURCES  = ../common/Clarf.test.cpp $(test_srcdepends)
+Clarf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clarft_test_dd_SOURCES  = ../common/Clarft.test.cpp $(test_srcdepends)
+Clarft_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarft_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clartg_test_dd_SOURCES  = ../common/Clartg.test.cpp $(test_srcdepends)
+Clartg_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clartg_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clascl_test_dd_SOURCES  = ../common/Clascl.test.cpp $(test_srcdepends)
+Clascl_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clascl_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Claset_test_dd_SOURCES  = ../common/Claset.test.cpp $(test_srcdepends)
+Claset_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claset_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clasr_test_dd_SOURCES  = ../common/Clasr.test.cpp $(test_srcdepends)
+Clasr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Classq_test_dd_SOURCES  = ../common/Classq.test.cpp $(test_srcdepends)
+Classq_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Classq_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Claswp_test_dd_SOURCES  = ../common/Claswp.test.cpp $(test_srcdepends)
+Claswp_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claswp_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clasyf_test_dd_SOURCES  = ../common/Clasyf.test.cpp $(test_srcdepends)
+Clasyf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasyf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Clatrd_test_dd_SOURCES  = ../common/Clatrd.test.cpp $(test_srcdepends)
+Clatrd_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clatrd_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cpotf2_test_dd_SOURCES  = ../common/Cpotf2.test.cpp $(test_srcdepends)
+Cpotf2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cpotf2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Crot_test_dd_SOURCES  = ../common/Crot.test.cpp $(test_srcdepends)
+Crot_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Crot_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cspmv_test_dd_SOURCES  = ../common/Cspmv.test.cpp $(test_srcdepends)
+Cspmv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspmv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cspr_test_dd_SOURCES  = ../common/Cspr.test.cpp $(test_srcdepends)
+Cspr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Csteqr_test_dd_SOURCES  = ../common/Csteqr.test.cpp $(test_srcdepends)
+Csteqr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csteqr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Csymv_test_dd_SOURCES  = ../common/Csymv.test.cpp $(test_srcdepends)
+Csymv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csymv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Csyr_test_dd_SOURCES  = ../common/Csyr.test.cpp $(test_srcdepends)
+Csyr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csyr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Ctrti2_test_dd_SOURCES  = ../common/Ctrti2.test.cpp $(test_srcdepends)
+Ctrti2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrti2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Ctrtri_test_dd_SOURCES  = ../common/Ctrtri.test.cpp $(test_srcdepends)
+Ctrtri_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtri_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Ctrtrs_test_dd_SOURCES  = ../common/Ctrtrs.test.cpp $(test_srcdepends)
+Ctrtrs_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtrs_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cung2l_test_dd_SOURCES  = ../common/Cung2l.test.cpp $(test_srcdepends)
+Cung2l_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2l_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cung2r_test_dd_SOURCES  = ../common/Cung2r.test.cpp $(test_srcdepends)
+Cung2r_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2r_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cungql_test_dd_SOURCES  = ../common/Cungql.test.cpp $(test_srcdepends)
+Cungql_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungql_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cungqr_test_dd_SOURCES  = ../common/Cungqr.test.cpp $(test_srcdepends)
+Cungqr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungqr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cungtr_test_dd_SOURCES  = ../common/Cungtr.test.cpp $(test_srcdepends)
+Cungtr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungtr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Cunmqr_test_dd_SOURCES  = ../common/Cunmqr.test.cpp $(test_srcdepends)
+Cunmqr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cunmqr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+iCmax1_test_dd_SOURCES  = ../common/iCmax1.test.cpp $(test_srcdepends)
+iCmax1_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+iCmax1_test_dd_CXXFLAGS = $(test_cxxflags)
+
+iMlaenv_test_dd_SOURCES  = ../common/iMlaenv.test.cpp $(test_srcdepends)
+iMlaenv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+iMlaenv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Mlsamen_test_dd_SOURCES  = ../common/Mlsamen.test.cpp $(test_srcdepends)
+Mlsamen_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mlsamen_test_dd_CXXFLAGS = $(test_cxxflags)
+
+RCsum1_test_dd_SOURCES  = ../common/RCsum1.test.cpp $(test_srcdepends)
+RCsum1_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+RCsum1_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rgecon_test_dd_SOURCES  = ../common/Rgecon.test.cpp $(test_srcdepends)
+Rgecon_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgecon_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rgeequ_test_dd_SOURCES  = ../common/Rgeequ.test.cpp $(test_srcdepends)
+Rgeequ_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeequ_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rgeqlf_test_dd_SOURCES  = ../common/Rgeqlf.test.cpp $(test_srcdepends)
+Rgeqlf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeqlf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rgesv_test_dd_SOURCES  = ../common/Rgesv.test.cpp $(test_srcdepends)
+Rgesv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgesv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rgetf2_test_dd_SOURCES  = ../common/Rgetf2.test.cpp $(test_srcdepends)
+Rgetf2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetf2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rgetrf_test_dd_SOURCES  = ../common/Rgetrf.test.cpp $(test_srcdepends)
+Rgetrf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rgetri_test_dd_SOURCES  = ../common/Rgetri.test.cpp $(test_srcdepends)
+Rgetri_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetri_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rgetrs_test_dd_SOURCES  = ../common/Rgetrs.test.cpp $(test_srcdepends)
+Rgetrs_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrs_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rladiv_test_dd_SOURCES  = ../common/Rladiv.test.cpp $(test_srcdepends)
+Rladiv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rladiv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlae2_test_dd_SOURCES  = ../common/Rlae2.test.cpp $(test_srcdepends)
+Rlae2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlae2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlaev2_test_dd_SOURCES  = ../common/Rlaev2.test.cpp $(test_srcdepends)
+Rlaev2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaev2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlamch_test_dd_SOURCES  = ../common/Rlamch.test.cpp $(test_srcdepends)
+Rlamch_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlamch_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlange_test_dd_SOURCES  = ../common/Rlange.test.cpp $(test_srcdepends)
+Rlange_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlange_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlanst_test_dd_SOURCES  = ../common/Rlanst.test.cpp $(test_srcdepends)
+Rlanst_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlanst_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlansy_test_dd_SOURCES  = ../common/Rlansy.test.cpp $(test_srcdepends)
+Rlansy_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlansy_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlapy2_test_dd_SOURCES  = ../common/Rlapy2.test.cpp $(test_srcdepends)
+Rlapy2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlapy3_test_dd_SOURCES  = ../common/Rlapy3.test.cpp $(test_srcdepends)
+Rlapy3_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy3_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlarfb_test_dd_SOURCES  = ../common/Rlarfb.test.cpp $(test_srcdepends)
+Rlarfb_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfb_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlarfg_test_dd_SOURCES  = ../common/Rlarfg.test.cpp $(test_srcdepends)
+Rlarfg_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfg_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlarf_test_dd_SOURCES  = ../common/Rlarf.test.cpp $(test_srcdepends)
+Rlarf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlarft_test_dd_SOURCES  = ../common/Rlarft.test.cpp $(test_srcdepends)
+Rlarft_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarft_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlartg_test_dd_SOURCES  = ../common/Rlartg.test.cpp $(test_srcdepends)
+Rlartg_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlartg_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlaruv_test_dd_SOURCES  = ../common/Rlaruv.test.cpp $(test_srcdepends)
+Rlaruv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaruv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlascl_test_dd_SOURCES  = ../common/Rlascl.test.cpp $(test_srcdepends)
+Rlascl_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlascl_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlaset_test_dd_SOURCES  = ../common/Rlaset.test.cpp $(test_srcdepends)
+Rlaset_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaset_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlasr_test_dd_SOURCES  = ../common/Rlasr.test.cpp $(test_srcdepends)
+Rlasr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlasrt_test_dd_SOURCES  = ../common/Rlasrt.test.cpp $(test_srcdepends)
+Rlasrt_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasrt_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlassq_test_dd_SOURCES  = ../common/Rlassq.test.cpp $(test_srcdepends)
+Rlassq_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlassq_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlaswp_test_dd_SOURCES  = ../common/Rlaswp.test.cpp $(test_srcdepends)
+Rlaswp_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaswp_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlasyf_test_dd_SOURCES  = ../common/Rlasyf.test.cpp $(test_srcdepends)
+Rlasyf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasyf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlatrd_test_dd_SOURCES  = ../common/Rlatrd.test.cpp $(test_srcdepends)
+Rlatrd_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrd_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlatrs_test_dd_SOURCES  = ../common/Rlatrs.test.cpp $(test_srcdepends)
+Rlatrs_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrs_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlauu2_test_dd_SOURCES  = ../common/Rlauu2.test.cpp $(test_srcdepends)
+Rlauu2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauu2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rlauum_test_dd_SOURCES  = ../common/Rlauum.test.cpp $(test_srcdepends)
+Rlauum_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauum_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rnaninf_test_dd_SOURCES  = ../common/Rnaninf.test.cpp $(test_srcdepends)
+Rnaninf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rnaninf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rorg2l_test_dd_SOURCES  = ../common/Rorg2l.test.cpp $(test_srcdepends)
+Rorg2l_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2l_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rorg2r_test_dd_SOURCES  = ../common/Rorg2r.test.cpp $(test_srcdepends)
+Rorg2r_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2r_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rorgql_test_dd_SOURCES  = ../common/Rorgql.test.cpp $(test_srcdepends)
+Rorgql_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgql_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rorgqr_test_dd_SOURCES  = ../common/Rorgqr.test.cpp $(test_srcdepends)
+Rorgqr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgqr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rorgtr_test_dd_SOURCES  = ../common/Rorgtr.test.cpp $(test_srcdepends)
+Rorgtr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgtr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rpocon_test_dd_SOURCES  = ../common/Rpocon.test.cpp $(test_srcdepends)
+Rpocon_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpocon_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rposv_test_dd_SOURCES  = ../common/Rposv.test.cpp $(test_srcdepends)
+Rposv_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rposv_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rpotf2_test_dd_SOURCES  = ../common/Rpotf2.test.cpp $(test_srcdepends)
+Rpotf2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotf2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rpotri_test_dd_SOURCES  = ../common/Rpotri.test.cpp $(test_srcdepends)
+Rpotri_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotri_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rpotrs_test_dd_SOURCES  = ../common/Rpotrs.test.cpp $(test_srcdepends)
+Rpotrs_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotrs_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rsteqr_test_dd_SOURCES  = ../common/Rsteqr.test.cpp $(test_srcdepends)
+Rsteqr_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsteqr_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rsterf_test_dd_SOURCES  = ../common/Rsterf.test.cpp $(test_srcdepends)
+Rsterf_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsterf_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rsyev_test_dd_SOURCES  = ../common/Rsyev.test.cpp $(test_srcdepends)
+Rsyev_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsyev_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rsytd2_test_dd_SOURCES  = ../common/Rsytd2.test.cpp $(test_srcdepends)
+Rsytd2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytd2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rsytrd_test_dd_SOURCES  = ../common/Rsytrd.test.cpp $(test_srcdepends)
+Rsytrd_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytrd_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rtrti2_test_dd_SOURCES  = ../common/Rtrti2.test.cpp $(test_srcdepends)
+Rtrti2_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrti2_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rtrtri_test_dd_SOURCES  = ../common/Rtrtri.test.cpp $(test_srcdepends)
+Rtrtri_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtri_test_dd_CXXFLAGS = $(test_cxxflags)
+
+Rtrtrs_test_dd_SOURCES  = ../common/Rtrtrs.test.cpp $(test_srcdepends)
+Rtrtrs_test_dd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtrs_test_dd_CXXFLAGS = $(test_cxxflags)
+
+
+

--- a/mplapack/test/compare/double/Makefile.am
+++ b/mplapack/test/compare/double/Makefile.am
@@ -1,0 +1,612 @@
+check_PROGRAMS = $(mplapack_double_test_PROGRAMS)
+TESTS = run_Rlaruv_test.sh run_Rlamch_test.sh
+CLEANFILES = run_Rlaruv_test.sh run_Rlamch_test.sh Rlaruv.txt Rlamch.txt
+
+TEST_EXTENSIONS = .sh
+SH_LOG_COMPILER = $(SHELL)
+
+AM_TESTS_ENVIRONMENT = \
+    LOG_COMPILER='$(LOG_COMPILER)'; export LOG_COMPILER; \
+    EXEEXT='$(EXEEXT)'; export EXEEXT; \
+    srcdir='$(srcdir)'; export srcdir;
+
+run_Rlaruv_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlaruv.test_double$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlaruv_reference.txt Rlaruv.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlaruv"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlaruv"; diff $${srcdir}/Rlaruv_reference.txt Rlaruv.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+run_Rlamch_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlamch.test_double$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlamch_reference.txt Rlamch.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlamch"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlamch"; diff $${srcdir}/Rlamch_reference.txt Rlamch.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+EXTRA_DIST = Rlaruv_reference.txt Rlamch_reference.txt
+
+.PHONY: check-all
+check-all: $(check_PROGRAMS)
+	$(MAKE) $(AM_MAKEFLAGS) check TESTS="$(mplapack_double_test_PROGRAMS)"
+mplapack_double_test_PROGRAMS = \
+Cgelq2.test_double \
+Cgeqr2.test_double \
+Cgeqrf.test_double \
+Cgesv.test_double \
+Cgetf2.test_double \
+Cgetrf.test_double \
+Cgetri.test_double \
+Cgetrs.test_double \
+Cheev.test_double \
+Chetd2.test_double \
+Chetrd.test_double \
+Clacgv.test_double \
+Clacrm.test_double \
+Clacrt.test_double \
+Cladiv.test_double \
+Claesy.test_double \
+Claev2.test_double \
+Clahef.test_double \
+Clanhe.test_double \
+Clanht.test_double \
+Clansy.test_double \
+Clarfb.test_double \
+Clarfg.test_double \
+Clarf.test_double \
+Clarft.test_double \
+Clartg.test_double \
+Clascl.test_double \
+Claset.test_double \
+Clasr.test_double \
+Classq.test_double \
+Claswp.test_double \
+Clasyf.test_double \
+Clatrd.test_double \
+Cpotf2.test_double \
+Crot.test_double \
+Cspmv.test_double \
+Cspr.test_double \
+Csteqr.test_double \
+Csymv.test_double \
+Csyr.test_double \
+Ctrti2.test_double \
+Ctrtri.test_double \
+Ctrtrs.test_double \
+Cung2l.test_double \
+Cung2r.test_double \
+Cungql.test_double \
+Cungqr.test_double \
+Cungtr.test_double \
+Cunmqr.test_double \
+iCmax1.test_double \
+iMlaenv.test_double \
+Mlsamen.test_double \
+Mutils.test_double \
+RCsum1.test_double \
+Rgecon.test_double \
+Rgeequ.test_double \
+Rgeqlf.test_double \
+Rgesv.test_double \
+Rgetf2.test_double \
+Rgetrf.test_double \
+Rgetri.test_double \
+Rgetrs.test_double \
+Rladiv.test_double \
+Rlae2.test_double \
+Rlaev2.test_double \
+Rlamch.test_double \
+Rlange.test_double \
+Rlanst.test_double \
+Rlansy.test_double \
+Rlapy2.test_double \
+Rlapy3.test_double \
+Rlarfb.test_double \
+Rlarfg.test_double \
+Rlarf.test_double \
+Rlarft.test_double \
+Rlartg.test_double \
+Rlaruv.test_double \
+Rlascl.test_double \
+Rlaset.test_double \
+Rlasr.test_double \
+Rlasrt.test_double \
+Rlassq.test_double \
+Rlaswp.test_double \
+Rlasyf.test_double \
+Rlatrd.test_double \
+Rlatrs.test_double \
+Rlauu2.test_double \
+Rlauum.test_double \
+Rnaninf.test_double \
+Rorg2l.test_double \
+Rorg2r.test_double \
+Rorgql.test_double \
+Rorgqr.test_double \
+Rorgtr.test_double \
+Rpocon.test_double \
+Rposv.test_double \
+Rpotf2.test_double \
+Rpotri.test_double \
+Rpotrs.test_double \
+Rsteqr.test_double \
+Rsterf.test_double \
+Rsyev.test_double \
+Rsytd2.test_double \
+Rsytrd.test_double \
+Rtrti2.test_double \
+Rtrtri.test_double \
+Rtrtrs.test_double 
+
+
+mplapack_double_testdir = $(prefix)/lib/$(target)/mplapack/test/compare/double
+
+install-data-hook:
+if IS_MACOS
+	bash $(top_srcdir)/misc/fix_dylib_macOS.sh $(mplapack_double_testdir) $(prefix)
+endif
+
+mplibs=-L$(MPC_LIBDIR) -L$(MPFR_LIBDIR) -lmpc -lmpfr -lgmpxx -lgmp
+refblas=-L$(top_builddir)/external/i/LAPACK/lib -lblas $(FCLIBS)
+reflapack=-L$(top_builddir)/external/i/LAPACK/lib -llapack $(FCLIBS)
+
+test_cxxflags = $(OPENMP_CXXFLAGS) -I$(top_srcdir)/include -I$(GMP_INCLUDEDIR) -I$(MPFR_INCLUDEDIR) -I$(MPC_INCLUDEDIR) -I$(top_srcdir)/mpfrc++ -D___MPLAPACK_BUILD_WITH_DOUBLE___ -D___MPLAPACK_INTERNAL___
+AM_FFLAGS = -x f77-cpp-input -g
+
+test_srcdepends = ../../../../mpblas/test/common/xerbla.cpp ../../../../mpblas/test/common/mplapack.test.cpp
+
+if IS_MACOS
+mplibs+=-Wl,-flat_namespace,-undefined,dynamic_lookup
+endif
+
+if IS_MINGW
+$(check_PROGRAMS): libmxerbla_override.la
+lib_LTLIBRARIES = libmxerbla_override.la
+libmxerbla_override_la_CPPFLAGS = -I$(top_srcdir)/include -D___MPLAPACK_BUILD_WITH_DOUBLE___
+libmxerbla_override_la_SOURCES = ../../../../mpblas/test/common/Mxerbla.override.cpp
+libmxerbla_override_la_LDFLAGS = -no-undefined
+
+test_libdepends = $(mplibs) $(reflapack) $(refblas) -Wl,--allow-multiple-definition
+libdepends = -Wl,--allow-multiple-definition -Wl,--whole-archive,.libs/libmxerbla_override.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_double.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_double.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_mpfr.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_mpfr.a,--no-whole-archive
+else
+test_srcdepends += ../../../../mpblas/test/common/Mxerbla.override.cpp
+test_libdepends = $(mplibs) $(reflapack) $(refblas)
+libdepends = -L$(top_builddir)/mplapack/reference -lmplapack_double -lmplapack_mpfr -L$(top_builddir)/mpblas/reference -lmpblas_double -lmpblas_mpfr
+endif
+
+Mutils_test_double_SOURCES  = ../common/Mutils.test.cpp $(test_srcdepends) ../common/ilaenv.cpp
+Mutils_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mutils_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cgelq2_test_double_SOURCES  = ../common/Cgelq2.test.cpp $(test_srcdepends)
+Cgelq2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgelq2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cgeqr2_test_double_SOURCES  = ../common/Cgeqr2.test.cpp $(test_srcdepends)
+Cgeqr2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqr2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cgeqrf_test_double_SOURCES  = ../common/Cgeqrf.test.cpp $(test_srcdepends)
+Cgeqrf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqrf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cgesv_test_double_SOURCES  = ../common/Cgesv.test.cpp $(test_srcdepends)
+Cgesv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgesv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cgetf2_test_double_SOURCES  = ../common/Cgetf2.test.cpp $(test_srcdepends)
+Cgetf2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetf2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cgetrf_test_double_SOURCES  = ../common/Cgetrf.test.cpp $(test_srcdepends)
+Cgetrf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cgetri_test_double_SOURCES  = ../common/Cgetri.test.cpp $(test_srcdepends)
+Cgetri_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetri_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cgetrs_test_double_SOURCES  = ../common/Cgetrs.test.cpp $(test_srcdepends)
+Cgetrs_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrs_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cheev_test_double_SOURCES  = ../common/Cheev.test.cpp $(test_srcdepends)
+Cheev_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cheev_test_double_CXXFLAGS = $(test_cxxflags)
+
+Chetd2_test_double_SOURCES  = ../common/Chetd2.test.cpp $(test_srcdepends)
+Chetd2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetd2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Chetrd_test_double_SOURCES  = ../common/Chetrd.test.cpp $(test_srcdepends)
+Chetrd_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetrd_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clacgv_test_double_SOURCES  = ../common/Clacgv.test.cpp $(test_srcdepends)
+Clacgv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacgv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clacrm_test_double_SOURCES  = ../common/Clacrm.test.cpp $(test_srcdepends)
+Clacrm_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrm_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clacrt_test_double_SOURCES  = ../common/Clacrt.test.cpp $(test_srcdepends)
+Clacrt_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrt_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cladiv_test_double_SOURCES  = ../common/Cladiv.test.cpp $(test_srcdepends)
+Cladiv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cladiv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Claesy_test_double_SOURCES  = ../common/Claesy.test.cpp $(test_srcdepends)
+Claesy_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claesy_test_double_CXXFLAGS = $(test_cxxflags)
+
+Claev2_test_double_SOURCES  = ../common/Claev2.test.cpp $(test_srcdepends)
+Claev2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claev2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clahef_test_double_SOURCES  = ../common/Clahef.test.cpp $(test_srcdepends)
+Clahef_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clahef_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clanhe_test_double_SOURCES  = ../common/Clanhe.test.cpp $(test_srcdepends)
+Clanhe_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanhe_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clanht_test_double_SOURCES  = ../common/Clanht.test.cpp $(test_srcdepends)
+Clanht_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanht_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clansy_test_double_SOURCES  = ../common/Clansy.test.cpp $(test_srcdepends)
+Clansy_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clansy_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clarfb_test_double_SOURCES  = ../common/Clarfb.test.cpp $(test_srcdepends)
+Clarfb_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfb_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clarfg_test_double_SOURCES  = ../common/Clarfg.test.cpp $(test_srcdepends)
+Clarfg_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfg_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clarf_test_double_SOURCES  = ../common/Clarf.test.cpp $(test_srcdepends)
+Clarf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clarft_test_double_SOURCES  = ../common/Clarft.test.cpp $(test_srcdepends)
+Clarft_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarft_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clartg_test_double_SOURCES  = ../common/Clartg.test.cpp $(test_srcdepends)
+Clartg_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clartg_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clascl_test_double_SOURCES  = ../common/Clascl.test.cpp $(test_srcdepends)
+Clascl_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clascl_test_double_CXXFLAGS = $(test_cxxflags)
+
+Claset_test_double_SOURCES  = ../common/Claset.test.cpp $(test_srcdepends)
+Claset_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claset_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clasr_test_double_SOURCES  = ../common/Clasr.test.cpp $(test_srcdepends)
+Clasr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Classq_test_double_SOURCES  = ../common/Classq.test.cpp $(test_srcdepends)
+Classq_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Classq_test_double_CXXFLAGS = $(test_cxxflags)
+
+Claswp_test_double_SOURCES  = ../common/Claswp.test.cpp $(test_srcdepends)
+Claswp_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claswp_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clasyf_test_double_SOURCES  = ../common/Clasyf.test.cpp $(test_srcdepends)
+Clasyf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasyf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Clatrd_test_double_SOURCES  = ../common/Clatrd.test.cpp $(test_srcdepends)
+Clatrd_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clatrd_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cpotf2_test_double_SOURCES  = ../common/Cpotf2.test.cpp $(test_srcdepends)
+Cpotf2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cpotf2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Crot_test_double_SOURCES  = ../common/Crot.test.cpp $(test_srcdepends)
+Crot_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Crot_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cspmv_test_double_SOURCES  = ../common/Cspmv.test.cpp $(test_srcdepends)
+Cspmv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspmv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cspr_test_double_SOURCES  = ../common/Cspr.test.cpp $(test_srcdepends)
+Cspr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Csteqr_test_double_SOURCES  = ../common/Csteqr.test.cpp $(test_srcdepends)
+Csteqr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csteqr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Csymv_test_double_SOURCES  = ../common/Csymv.test.cpp $(test_srcdepends)
+Csymv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csymv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Csyr_test_double_SOURCES  = ../common/Csyr.test.cpp $(test_srcdepends)
+Csyr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csyr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Ctrti2_test_double_SOURCES  = ../common/Ctrti2.test.cpp $(test_srcdepends)
+Ctrti2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrti2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Ctrtri_test_double_SOURCES  = ../common/Ctrtri.test.cpp $(test_srcdepends)
+Ctrtri_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtri_test_double_CXXFLAGS = $(test_cxxflags)
+
+Ctrtrs_test_double_SOURCES  = ../common/Ctrtrs.test.cpp $(test_srcdepends)
+Ctrtrs_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtrs_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cung2l_test_double_SOURCES  = ../common/Cung2l.test.cpp $(test_srcdepends)
+Cung2l_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2l_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cung2r_test_double_SOURCES  = ../common/Cung2r.test.cpp $(test_srcdepends)
+Cung2r_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2r_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cungql_test_double_SOURCES  = ../common/Cungql.test.cpp $(test_srcdepends)
+Cungql_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungql_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cungqr_test_double_SOURCES  = ../common/Cungqr.test.cpp $(test_srcdepends)
+Cungqr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungqr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cungtr_test_double_SOURCES  = ../common/Cungtr.test.cpp $(test_srcdepends)
+Cungtr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungtr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Cunmqr_test_double_SOURCES  = ../common/Cunmqr.test.cpp $(test_srcdepends)
+Cunmqr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cunmqr_test_double_CXXFLAGS = $(test_cxxflags)
+
+iCmax1_test_double_SOURCES  = ../common/iCmax1.test.cpp $(test_srcdepends)
+iCmax1_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+iCmax1_test_double_CXXFLAGS = $(test_cxxflags)
+
+iMlaenv_test_double_SOURCES  = ../common/iMlaenv.test.cpp $(test_srcdepends)
+iMlaenv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+iMlaenv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Mlsamen_test_double_SOURCES  = ../common/Mlsamen.test.cpp $(test_srcdepends)
+Mlsamen_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mlsamen_test_double_CXXFLAGS = $(test_cxxflags)
+
+RCsum1_test_double_SOURCES  = ../common/RCsum1.test.cpp $(test_srcdepends)
+RCsum1_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+RCsum1_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rgecon_test_double_SOURCES  = ../common/Rgecon.test.cpp $(test_srcdepends)
+Rgecon_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgecon_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rgeequ_test_double_SOURCES  = ../common/Rgeequ.test.cpp $(test_srcdepends)
+Rgeequ_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeequ_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rgeqlf_test_double_SOURCES  = ../common/Rgeqlf.test.cpp $(test_srcdepends)
+Rgeqlf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeqlf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rgesv_test_double_SOURCES  = ../common/Rgesv.test.cpp $(test_srcdepends)
+Rgesv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgesv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rgetf2_test_double_SOURCES  = ../common/Rgetf2.test.cpp $(test_srcdepends)
+Rgetf2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetf2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rgetrf_test_double_SOURCES  = ../common/Rgetrf.test.cpp $(test_srcdepends)
+Rgetrf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rgetri_test_double_SOURCES  = ../common/Rgetri.test.cpp $(test_srcdepends)
+Rgetri_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetri_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rgetrs_test_double_SOURCES  = ../common/Rgetrs.test.cpp $(test_srcdepends)
+Rgetrs_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrs_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rladiv_test_double_SOURCES  = ../common/Rladiv.test.cpp $(test_srcdepends)
+Rladiv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rladiv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlae2_test_double_SOURCES  = ../common/Rlae2.test.cpp $(test_srcdepends)
+Rlae2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlae2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlaev2_test_double_SOURCES  = ../common/Rlaev2.test.cpp $(test_srcdepends)
+Rlaev2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaev2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlamch_test_double_SOURCES  = ../common/Rlamch.test.cpp $(test_srcdepends)
+Rlamch_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlamch_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlange_test_double_SOURCES  = ../common/Rlange.test.cpp $(test_srcdepends)
+Rlange_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlange_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlanst_test_double_SOURCES  = ../common/Rlanst.test.cpp $(test_srcdepends)
+Rlanst_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlanst_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlansy_test_double_SOURCES  = ../common/Rlansy.test.cpp $(test_srcdepends)
+Rlansy_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlansy_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlapy2_test_double_SOURCES  = ../common/Rlapy2.test.cpp $(test_srcdepends)
+Rlapy2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlapy3_test_double_SOURCES  = ../common/Rlapy3.test.cpp $(test_srcdepends)
+Rlapy3_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy3_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlarfb_test_double_SOURCES  = ../common/Rlarfb.test.cpp $(test_srcdepends)
+Rlarfb_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfb_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlarfg_test_double_SOURCES  = ../common/Rlarfg.test.cpp $(test_srcdepends)
+Rlarfg_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfg_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlarf_test_double_SOURCES  = ../common/Rlarf.test.cpp $(test_srcdepends)
+Rlarf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlarft_test_double_SOURCES  = ../common/Rlarft.test.cpp $(test_srcdepends)
+Rlarft_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarft_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlartg_test_double_SOURCES  = ../common/Rlartg.test.cpp $(test_srcdepends)
+Rlartg_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlartg_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlaruv_test_double_SOURCES  = ../common/Rlaruv.test.cpp $(test_srcdepends)
+Rlaruv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaruv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlascl_test_double_SOURCES  = ../common/Rlascl.test.cpp $(test_srcdepends)
+Rlascl_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlascl_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlaset_test_double_SOURCES  = ../common/Rlaset.test.cpp $(test_srcdepends)
+Rlaset_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaset_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlasr_test_double_SOURCES  = ../common/Rlasr.test.cpp $(test_srcdepends)
+Rlasr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlasrt_test_double_SOURCES  = ../common/Rlasrt.test.cpp $(test_srcdepends)
+Rlasrt_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasrt_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlassq_test_double_SOURCES  = ../common/Rlassq.test.cpp $(test_srcdepends)
+Rlassq_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlassq_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlaswp_test_double_SOURCES  = ../common/Rlaswp.test.cpp $(test_srcdepends)
+Rlaswp_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaswp_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlasyf_test_double_SOURCES  = ../common/Rlasyf.test.cpp $(test_srcdepends)
+Rlasyf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasyf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlatrd_test_double_SOURCES  = ../common/Rlatrd.test.cpp $(test_srcdepends)
+Rlatrd_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrd_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlatrs_test_double_SOURCES  = ../common/Rlatrs.test.cpp $(test_srcdepends)
+Rlatrs_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrs_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlauu2_test_double_SOURCES  = ../common/Rlauu2.test.cpp $(test_srcdepends)
+Rlauu2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauu2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rlauum_test_double_SOURCES  = ../common/Rlauum.test.cpp $(test_srcdepends)
+Rlauum_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauum_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rnaninf_test_double_SOURCES  = ../common/Rnaninf.test.cpp $(test_srcdepends)
+Rnaninf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rnaninf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rorg2l_test_double_SOURCES  = ../common/Rorg2l.test.cpp $(test_srcdepends)
+Rorg2l_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2l_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rorg2r_test_double_SOURCES  = ../common/Rorg2r.test.cpp $(test_srcdepends)
+Rorg2r_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2r_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rorgql_test_double_SOURCES  = ../common/Rorgql.test.cpp $(test_srcdepends)
+Rorgql_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgql_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rorgqr_test_double_SOURCES  = ../common/Rorgqr.test.cpp $(test_srcdepends)
+Rorgqr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgqr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rorgtr_test_double_SOURCES  = ../common/Rorgtr.test.cpp $(test_srcdepends)
+Rorgtr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgtr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rpocon_test_double_SOURCES  = ../common/Rpocon.test.cpp $(test_srcdepends)
+Rpocon_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpocon_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rposv_test_double_SOURCES  = ../common/Rposv.test.cpp $(test_srcdepends)
+Rposv_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rposv_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rpotf2_test_double_SOURCES  = ../common/Rpotf2.test.cpp $(test_srcdepends)
+Rpotf2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotf2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rpotri_test_double_SOURCES  = ../common/Rpotri.test.cpp $(test_srcdepends)
+Rpotri_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotri_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rpotrs_test_double_SOURCES  = ../common/Rpotrs.test.cpp $(test_srcdepends)
+Rpotrs_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotrs_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rsteqr_test_double_SOURCES  = ../common/Rsteqr.test.cpp $(test_srcdepends)
+Rsteqr_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsteqr_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rsterf_test_double_SOURCES  = ../common/Rsterf.test.cpp $(test_srcdepends)
+Rsterf_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsterf_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rsyev_test_double_SOURCES  = ../common/Rsyev.test.cpp $(test_srcdepends)
+Rsyev_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsyev_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rsytd2_test_double_SOURCES  = ../common/Rsytd2.test.cpp $(test_srcdepends)
+Rsytd2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytd2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rsytrd_test_double_SOURCES  = ../common/Rsytrd.test.cpp $(test_srcdepends)
+Rsytrd_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytrd_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rtrti2_test_double_SOURCES  = ../common/Rtrti2.test.cpp $(test_srcdepends)
+Rtrti2_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrti2_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rtrtri_test_double_SOURCES  = ../common/Rtrtri.test.cpp $(test_srcdepends)
+Rtrtri_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtri_test_double_CXXFLAGS = $(test_cxxflags)
+
+Rtrtrs_test_double_SOURCES  = ../common/Rtrtrs.test.cpp $(test_srcdepends)
+Rtrtrs_test_double_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtrs_test_double_CXXFLAGS = $(test_cxxflags)
+
+
+

--- a/mplapack/test/compare/gmp/Makefile.am
+++ b/mplapack/test/compare/gmp/Makefile.am
@@ -1,0 +1,613 @@
+check_PROGRAMS = $(mplapack_gmp_test_PROGRAMS)
+TESTS = run_Rlaruv_test.sh run_Rlamch_test.sh
+CLEANFILES = run_Rlaruv_test.sh run_Rlamch_test.sh Rlaruv.txt Rlamch.txt
+
+TEST_EXTENSIONS = .sh
+SH_LOG_COMPILER = $(SHELL)
+
+AM_TESTS_ENVIRONMENT = \
+    LOG_COMPILER='$(LOG_COMPILER)'; export LOG_COMPILER; \
+    EXEEXT='$(EXEEXT)'; export EXEEXT; \
+    srcdir='$(srcdir)'; export srcdir;
+
+run_Rlaruv_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlaruv.test_gmp$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlaruv_reference.txt Rlaruv.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlaruv"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlaruv"; diff $${srcdir}/Rlaruv_reference.txt Rlaruv.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+run_Rlamch_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlamch.test_gmp$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlamch_reference@ABI_BITS@.txt Rlamch.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlamch (@ABI_BITS@-bit)"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlamch (@ABI_BITS@-bit)"; diff $${srcdir}/Rlamch_reference@ABI_BITS@.txt Rlamch.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+EXTRA_DIST = Rlamch_reference32.txt Rlamch_reference64.txt Rlaruv_reference.txt
+
+.PHONY: check-all
+check-all: $(check_PROGRAMS)
+	$(MAKE) $(AM_MAKEFLAGS) check TESTS="$(mplapack_gmp_test_PROGRAMS)"
+
+mplapack_gmp_test_PROGRAMS = \
+Cgelq2.test_gmp \
+Cgeqr2.test_gmp \
+Cgeqrf.test_gmp \
+Cgesv.test_gmp \
+Cgetf2.test_gmp \
+Cgetrf.test_gmp \
+Cgetri.test_gmp \
+Cgetrs.test_gmp \
+Cheev.test_gmp \
+Chetd2.test_gmp \
+Chetrd.test_gmp \
+Clacgv.test_gmp \
+Clacrm.test_gmp \
+Clacrt.test_gmp \
+Cladiv.test_gmp \
+Claesy.test_gmp \
+Claev2.test_gmp \
+Clahef.test_gmp \
+Clanhe.test_gmp \
+Clanht.test_gmp \
+Clansy.test_gmp \
+Clarfb.test_gmp \
+Clarfg.test_gmp \
+Clarf.test_gmp \
+Clarft.test_gmp \
+Clartg.test_gmp \
+Clascl.test_gmp \
+Claset.test_gmp \
+Clasr.test_gmp \
+Classq.test_gmp \
+Claswp.test_gmp \
+Clasyf.test_gmp \
+Clatrd.test_gmp \
+Cpotf2.test_gmp \
+Crot.test_gmp \
+Cspmv.test_gmp \
+Cspr.test_gmp \
+Csteqr.test_gmp \
+Csymv.test_gmp \
+Csyr.test_gmp \
+Ctrti2.test_gmp \
+Ctrtri.test_gmp \
+Ctrtrs.test_gmp \
+Cung2l.test_gmp \
+Cung2r.test_gmp \
+Cungql.test_gmp \
+Cungqr.test_gmp \
+Cungtr.test_gmp \
+Cunmqr.test_gmp \
+iCmax1.test_gmp \
+iMlaenv.test_gmp \
+Mlsamen.test_gmp \
+Mutils.test_gmp \
+RCsum1.test_gmp \
+Rgecon.test_gmp \
+Rgeequ.test_gmp \
+Rgeqlf.test_gmp \
+Rgesv.test_gmp \
+Rgetf2.test_gmp \
+Rgetrf.test_gmp \
+Rgetri.test_gmp \
+Rgetrs.test_gmp \
+Rladiv.test_gmp \
+Rlae2.test_gmp \
+Rlaev2.test_gmp \
+Rlamch.test_gmp \
+Rlange.test_gmp \
+Rlanst.test_gmp \
+Rlansy.test_gmp \
+Rlapy2.test_gmp \
+Rlapy3.test_gmp \
+Rlarfb.test_gmp \
+Rlarfg.test_gmp \
+Rlarf.test_gmp \
+Rlarft.test_gmp \
+Rlartg.test_gmp \
+Rlaruv.test_gmp \
+Rlascl.test_gmp \
+Rlaset.test_gmp \
+Rlasr.test_gmp \
+Rlasrt.test_gmp \
+Rlassq.test_gmp \
+Rlaswp.test_gmp \
+Rlasyf.test_gmp \
+Rlatrd.test_gmp \
+Rlatrs.test_gmp \
+Rlauu2.test_gmp \
+Rlauum.test_gmp \
+Rnaninf.test_gmp \
+Rorg2l.test_gmp \
+Rorg2r.test_gmp \
+Rorgql.test_gmp \
+Rorgqr.test_gmp \
+Rorgtr.test_gmp \
+Rpocon.test_gmp \
+Rposv.test_gmp \
+Rpotf2.test_gmp \
+Rpotri.test_gmp \
+Rpotrs.test_gmp \
+Rsteqr.test_gmp \
+Rsterf.test_gmp \
+Rsyev.test_gmp \
+Rsytd2.test_gmp \
+Rsytrd.test_gmp \
+Rtrti2.test_gmp \
+Rtrtri.test_gmp \
+Rtrtrs.test_gmp 
+
+
+mplapack_gmp_testdir = $(prefix)/lib/$(target)/mplapack/test/compare/gmp
+
+install-data-hook:
+if IS_MACOS
+	bash $(top_srcdir)/misc/fix_dylib_macOS.sh $(mplapack_gmp_testdir) $(prefix)
+endif
+
+mplibs=-L$(MPC_LIBDIR) -L$(MPFR_LIBDIR) -lmpc -lmpfr -lgmpxx -lgmp
+refblas=-L$(top_builddir)/external/i/LAPACK/lib -lblas $(FCLIBS)
+reflapack=-L$(top_builddir)/external/i/LAPACK/lib -llapack $(FCLIBS)
+
+test_cxxflags = $(OPENMP_CXXFLAGS) -I$(top_srcdir)/include -I$(GMP_INCLUDEDIR) -I$(MPFR_INCLUDEDIR) -I$(MPC_INCLUDEDIR) -I$(top_srcdir)/mpfrc++ -D___MPLAPACK_BUILD_WITH_GMP___ -D___MPLAPACK_INTERNAL___
+AM_FFLAGS = -x f77-cpp-input -g
+
+test_srcdepends = ../../../../mpblas/test/common/xerbla.cpp ../../../../mpblas/test/common/mplapack.test.cpp
+
+if IS_MACOS
+mplibs+=-Wl,-flat_namespace,-undefined,dynamic_lookup
+endif
+
+if IS_MINGW
+$(check_PROGRAMS): libmxerbla_override.la
+lib_LTLIBRARIES = libmxerbla_override.la
+libmxerbla_override_la_CPPFLAGS = -I$(top_srcdir)/include -D___MPLAPACK_BUILD_WITH_GMP___
+libmxerbla_override_la_SOURCES = ../../../../mpblas/test/common/Mxerbla.override.cpp
+libmxerbla_override_la_LDFLAGS = -no-undefined
+
+test_libdepends = $(mplibs) $(reflapack) $(refblas) -Wl,--allow-multiple-definition
+libdepends = -Wl,--allow-multiple-definition -Wl,--whole-archive,.libs/libmxerbla_override.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_gmp.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_gmp.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_mpfr.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_mpfr.a,--no-whole-archive
+else
+test_srcdepends += ../../../../mpblas/test/common/Mxerbla.override.cpp
+test_libdepends = $(mplibs) $(reflapack) $(refblas)
+libdepends = -L$(top_builddir)/mplapack/reference -lmplapack_gmp -lmplapack_mpfr -L$(top_builddir)/mpblas/reference -lmpblas_gmp -lmpblas_mpfr
+endif
+
+Mutils_test_gmp_SOURCES  = ../common/Mutils.test.cpp $(test_srcdepends) ../common/ilaenv.cpp
+Mutils_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mutils_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cgelq2_test_gmp_SOURCES  = ../common/Cgelq2.test.cpp $(test_srcdepends)
+Cgelq2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgelq2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cgeqr2_test_gmp_SOURCES  = ../common/Cgeqr2.test.cpp $(test_srcdepends)
+Cgeqr2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqr2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cgeqrf_test_gmp_SOURCES  = ../common/Cgeqrf.test.cpp $(test_srcdepends)
+Cgeqrf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqrf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cgesv_test_gmp_SOURCES  = ../common/Cgesv.test.cpp $(test_srcdepends)
+Cgesv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgesv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cgetf2_test_gmp_SOURCES  = ../common/Cgetf2.test.cpp $(test_srcdepends)
+Cgetf2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetf2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cgetrf_test_gmp_SOURCES  = ../common/Cgetrf.test.cpp $(test_srcdepends)
+Cgetrf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cgetri_test_gmp_SOURCES  = ../common/Cgetri.test.cpp $(test_srcdepends)
+Cgetri_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetri_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cgetrs_test_gmp_SOURCES  = ../common/Cgetrs.test.cpp $(test_srcdepends)
+Cgetrs_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrs_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cheev_test_gmp_SOURCES  = ../common/Cheev.test.cpp $(test_srcdepends)
+Cheev_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cheev_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Chetd2_test_gmp_SOURCES  = ../common/Chetd2.test.cpp $(test_srcdepends)
+Chetd2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetd2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Chetrd_test_gmp_SOURCES  = ../common/Chetrd.test.cpp $(test_srcdepends)
+Chetrd_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetrd_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clacgv_test_gmp_SOURCES  = ../common/Clacgv.test.cpp $(test_srcdepends)
+Clacgv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacgv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clacrm_test_gmp_SOURCES  = ../common/Clacrm.test.cpp $(test_srcdepends)
+Clacrm_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrm_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clacrt_test_gmp_SOURCES  = ../common/Clacrt.test.cpp $(test_srcdepends)
+Clacrt_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrt_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cladiv_test_gmp_SOURCES  = ../common/Cladiv.test.cpp $(test_srcdepends)
+Cladiv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cladiv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Claesy_test_gmp_SOURCES  = ../common/Claesy.test.cpp $(test_srcdepends)
+Claesy_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claesy_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Claev2_test_gmp_SOURCES  = ../common/Claev2.test.cpp $(test_srcdepends)
+Claev2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claev2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clahef_test_gmp_SOURCES  = ../common/Clahef.test.cpp $(test_srcdepends)
+Clahef_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clahef_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clanhe_test_gmp_SOURCES  = ../common/Clanhe.test.cpp $(test_srcdepends)
+Clanhe_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanhe_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clanht_test_gmp_SOURCES  = ../common/Clanht.test.cpp $(test_srcdepends)
+Clanht_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanht_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clansy_test_gmp_SOURCES  = ../common/Clansy.test.cpp $(test_srcdepends)
+Clansy_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clansy_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clarfb_test_gmp_SOURCES  = ../common/Clarfb.test.cpp $(test_srcdepends)
+Clarfb_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfb_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clarfg_test_gmp_SOURCES  = ../common/Clarfg.test.cpp $(test_srcdepends)
+Clarfg_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfg_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clarf_test_gmp_SOURCES  = ../common/Clarf.test.cpp $(test_srcdepends)
+Clarf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clarft_test_gmp_SOURCES  = ../common/Clarft.test.cpp $(test_srcdepends)
+Clarft_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarft_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clartg_test_gmp_SOURCES  = ../common/Clartg.test.cpp $(test_srcdepends)
+Clartg_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clartg_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clascl_test_gmp_SOURCES  = ../common/Clascl.test.cpp $(test_srcdepends)
+Clascl_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clascl_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Claset_test_gmp_SOURCES  = ../common/Claset.test.cpp $(test_srcdepends)
+Claset_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claset_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clasr_test_gmp_SOURCES  = ../common/Clasr.test.cpp $(test_srcdepends)
+Clasr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Classq_test_gmp_SOURCES  = ../common/Classq.test.cpp $(test_srcdepends)
+Classq_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Classq_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Claswp_test_gmp_SOURCES  = ../common/Claswp.test.cpp $(test_srcdepends)
+Claswp_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claswp_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clasyf_test_gmp_SOURCES  = ../common/Clasyf.test.cpp $(test_srcdepends)
+Clasyf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasyf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Clatrd_test_gmp_SOURCES  = ../common/Clatrd.test.cpp $(test_srcdepends)
+Clatrd_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clatrd_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cpotf2_test_gmp_SOURCES  = ../common/Cpotf2.test.cpp $(test_srcdepends)
+Cpotf2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cpotf2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Crot_test_gmp_SOURCES  = ../common/Crot.test.cpp $(test_srcdepends)
+Crot_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Crot_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cspmv_test_gmp_SOURCES  = ../common/Cspmv.test.cpp $(test_srcdepends)
+Cspmv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspmv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cspr_test_gmp_SOURCES  = ../common/Cspr.test.cpp $(test_srcdepends)
+Cspr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Csteqr_test_gmp_SOURCES  = ../common/Csteqr.test.cpp $(test_srcdepends)
+Csteqr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csteqr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Csymv_test_gmp_SOURCES  = ../common/Csymv.test.cpp $(test_srcdepends)
+Csymv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csymv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Csyr_test_gmp_SOURCES  = ../common/Csyr.test.cpp $(test_srcdepends)
+Csyr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csyr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Ctrti2_test_gmp_SOURCES  = ../common/Ctrti2.test.cpp $(test_srcdepends)
+Ctrti2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrti2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Ctrtri_test_gmp_SOURCES  = ../common/Ctrtri.test.cpp $(test_srcdepends)
+Ctrtri_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtri_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Ctrtrs_test_gmp_SOURCES  = ../common/Ctrtrs.test.cpp $(test_srcdepends)
+Ctrtrs_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtrs_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cung2l_test_gmp_SOURCES  = ../common/Cung2l.test.cpp $(test_srcdepends)
+Cung2l_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2l_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cung2r_test_gmp_SOURCES  = ../common/Cung2r.test.cpp $(test_srcdepends)
+Cung2r_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2r_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cungql_test_gmp_SOURCES  = ../common/Cungql.test.cpp $(test_srcdepends)
+Cungql_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungql_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cungqr_test_gmp_SOURCES  = ../common/Cungqr.test.cpp $(test_srcdepends)
+Cungqr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungqr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cungtr_test_gmp_SOURCES  = ../common/Cungtr.test.cpp $(test_srcdepends)
+Cungtr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungtr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Cunmqr_test_gmp_SOURCES  = ../common/Cunmqr.test.cpp $(test_srcdepends)
+Cunmqr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cunmqr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+iCmax1_test_gmp_SOURCES  = ../common/iCmax1.test.cpp $(test_srcdepends)
+iCmax1_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+iCmax1_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+iMlaenv_test_gmp_SOURCES  = ../common/iMlaenv.test.cpp $(test_srcdepends)
+iMlaenv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+iMlaenv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Mlsamen_test_gmp_SOURCES  = ../common/Mlsamen.test.cpp $(test_srcdepends)
+Mlsamen_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mlsamen_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+RCsum1_test_gmp_SOURCES  = ../common/RCsum1.test.cpp $(test_srcdepends)
+RCsum1_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+RCsum1_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rgecon_test_gmp_SOURCES  = ../common/Rgecon.test.cpp $(test_srcdepends)
+Rgecon_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgecon_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rgeequ_test_gmp_SOURCES  = ../common/Rgeequ.test.cpp $(test_srcdepends)
+Rgeequ_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeequ_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rgeqlf_test_gmp_SOURCES  = ../common/Rgeqlf.test.cpp $(test_srcdepends)
+Rgeqlf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeqlf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rgesv_test_gmp_SOURCES  = ../common/Rgesv.test.cpp $(test_srcdepends)
+Rgesv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgesv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rgetf2_test_gmp_SOURCES  = ../common/Rgetf2.test.cpp $(test_srcdepends)
+Rgetf2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetf2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rgetrf_test_gmp_SOURCES  = ../common/Rgetrf.test.cpp $(test_srcdepends)
+Rgetrf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rgetri_test_gmp_SOURCES  = ../common/Rgetri.test.cpp $(test_srcdepends)
+Rgetri_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetri_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rgetrs_test_gmp_SOURCES  = ../common/Rgetrs.test.cpp $(test_srcdepends)
+Rgetrs_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrs_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rladiv_test_gmp_SOURCES  = ../common/Rladiv.test.cpp $(test_srcdepends)
+Rladiv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rladiv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlae2_test_gmp_SOURCES  = ../common/Rlae2.test.cpp $(test_srcdepends)
+Rlae2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlae2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlaev2_test_gmp_SOURCES  = ../common/Rlaev2.test.cpp $(test_srcdepends)
+Rlaev2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaev2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlamch_test_gmp_SOURCES  = ../common/Rlamch.test.cpp $(test_srcdepends)
+Rlamch_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlamch_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlange_test_gmp_SOURCES  = ../common/Rlange.test.cpp $(test_srcdepends)
+Rlange_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlange_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlanst_test_gmp_SOURCES  = ../common/Rlanst.test.cpp $(test_srcdepends)
+Rlanst_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlanst_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlansy_test_gmp_SOURCES  = ../common/Rlansy.test.cpp $(test_srcdepends)
+Rlansy_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlansy_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlapy2_test_gmp_SOURCES  = ../common/Rlapy2.test.cpp $(test_srcdepends)
+Rlapy2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlapy3_test_gmp_SOURCES  = ../common/Rlapy3.test.cpp $(test_srcdepends)
+Rlapy3_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy3_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlarfb_test_gmp_SOURCES  = ../common/Rlarfb.test.cpp $(test_srcdepends)
+Rlarfb_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfb_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlarfg_test_gmp_SOURCES  = ../common/Rlarfg.test.cpp $(test_srcdepends)
+Rlarfg_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfg_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlarf_test_gmp_SOURCES  = ../common/Rlarf.test.cpp $(test_srcdepends)
+Rlarf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlarft_test_gmp_SOURCES  = ../common/Rlarft.test.cpp $(test_srcdepends)
+Rlarft_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarft_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlartg_test_gmp_SOURCES  = ../common/Rlartg.test.cpp $(test_srcdepends)
+Rlartg_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlartg_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlaruv_test_gmp_SOURCES  = ../common/Rlaruv.test.cpp $(test_srcdepends)
+Rlaruv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaruv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlascl_test_gmp_SOURCES  = ../common/Rlascl.test.cpp $(test_srcdepends)
+Rlascl_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlascl_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlaset_test_gmp_SOURCES  = ../common/Rlaset.test.cpp $(test_srcdepends)
+Rlaset_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaset_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlasr_test_gmp_SOURCES  = ../common/Rlasr.test.cpp $(test_srcdepends)
+Rlasr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlasrt_test_gmp_SOURCES  = ../common/Rlasrt.test.cpp $(test_srcdepends)
+Rlasrt_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasrt_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlassq_test_gmp_SOURCES  = ../common/Rlassq.test.cpp $(test_srcdepends)
+Rlassq_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlassq_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlaswp_test_gmp_SOURCES  = ../common/Rlaswp.test.cpp $(test_srcdepends)
+Rlaswp_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaswp_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlasyf_test_gmp_SOURCES  = ../common/Rlasyf.test.cpp $(test_srcdepends)
+Rlasyf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasyf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlatrd_test_gmp_SOURCES  = ../common/Rlatrd.test.cpp $(test_srcdepends)
+Rlatrd_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrd_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlatrs_test_gmp_SOURCES  = ../common/Rlatrs.test.cpp $(test_srcdepends)
+Rlatrs_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrs_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlauu2_test_gmp_SOURCES  = ../common/Rlauu2.test.cpp $(test_srcdepends)
+Rlauu2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauu2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rlauum_test_gmp_SOURCES  = ../common/Rlauum.test.cpp $(test_srcdepends)
+Rlauum_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauum_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rnaninf_test_gmp_SOURCES  = ../common/Rnaninf.test.cpp $(test_srcdepends)
+Rnaninf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rnaninf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rorg2l_test_gmp_SOURCES  = ../common/Rorg2l.test.cpp $(test_srcdepends)
+Rorg2l_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2l_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rorg2r_test_gmp_SOURCES  = ../common/Rorg2r.test.cpp $(test_srcdepends)
+Rorg2r_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2r_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rorgql_test_gmp_SOURCES  = ../common/Rorgql.test.cpp $(test_srcdepends)
+Rorgql_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgql_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rorgqr_test_gmp_SOURCES  = ../common/Rorgqr.test.cpp $(test_srcdepends)
+Rorgqr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgqr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rorgtr_test_gmp_SOURCES  = ../common/Rorgtr.test.cpp $(test_srcdepends)
+Rorgtr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgtr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rpocon_test_gmp_SOURCES  = ../common/Rpocon.test.cpp $(test_srcdepends)
+Rpocon_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpocon_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rposv_test_gmp_SOURCES  = ../common/Rposv.test.cpp $(test_srcdepends)
+Rposv_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rposv_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rpotf2_test_gmp_SOURCES  = ../common/Rpotf2.test.cpp $(test_srcdepends)
+Rpotf2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotf2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rpotri_test_gmp_SOURCES  = ../common/Rpotri.test.cpp $(test_srcdepends)
+Rpotri_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotri_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rpotrs_test_gmp_SOURCES  = ../common/Rpotrs.test.cpp $(test_srcdepends)
+Rpotrs_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotrs_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rsteqr_test_gmp_SOURCES  = ../common/Rsteqr.test.cpp $(test_srcdepends)
+Rsteqr_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsteqr_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rsterf_test_gmp_SOURCES  = ../common/Rsterf.test.cpp $(test_srcdepends)
+Rsterf_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsterf_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rsyev_test_gmp_SOURCES  = ../common/Rsyev.test.cpp $(test_srcdepends)
+Rsyev_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsyev_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rsytd2_test_gmp_SOURCES  = ../common/Rsytd2.test.cpp $(test_srcdepends)
+Rsytd2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytd2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rsytrd_test_gmp_SOURCES  = ../common/Rsytrd.test.cpp $(test_srcdepends)
+Rsytrd_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytrd_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rtrti2_test_gmp_SOURCES  = ../common/Rtrti2.test.cpp $(test_srcdepends)
+Rtrti2_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrti2_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rtrtri_test_gmp_SOURCES  = ../common/Rtrtri.test.cpp $(test_srcdepends)
+Rtrtri_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtri_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+Rtrtrs_test_gmp_SOURCES  = ../common/Rtrtrs.test.cpp $(test_srcdepends)
+Rtrtrs_test_gmp_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtrs_test_gmp_CXXFLAGS = $(test_cxxflags)
+
+
+

--- a/mplapack/test/compare/mpfr/Makefile.am
+++ b/mplapack/test/compare/mpfr/Makefile.am
@@ -1,0 +1,613 @@
+check_PROGRAMS = $(mplapack_mpfr_test_PROGRAMS)
+TESTS = run_Rlaruv_test.sh run_Rlamch_test.sh
+CLEANFILES = run_Rlaruv_test.sh run_Rlamch_test.sh Rlaruv.txt Rlamch.txt
+
+TEST_EXTENSIONS = .sh
+SH_LOG_COMPILER = $(SHELL)
+
+AM_TESTS_ENVIRONMENT = \
+    LOG_COMPILER='$(LOG_COMPILER)'; export LOG_COMPILER; \
+    EXEEXT='$(EXEEXT)'; export EXEEXT; \
+    srcdir='$(srcdir)'; export srcdir;
+
+run_Rlaruv_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlaruv.test_mpfr$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlaruv_reference.txt Rlaruv.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlaruv"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlaruv"; diff $${srcdir}/Rlaruv_reference.txt Rlaruv.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+run_Rlamch_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo '$${LOG_COMPILER} ./Rlamch.test_mpfr$${EXEEXT} || true' >> $@
+	@echo 'if diff -u $${srcdir}/Rlamch_reference.txt Rlamch.txt > /dev/null 2>&1; then' >> $@
+	@echo '  echo "PASS: Rlamch"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlamch"; diff $${srcdir}/Rlamch_reference.txt Rlamch.txt; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+EXTRA_DIST = Rlaruv_reference.txt Rlamch_reference.txt
+
+.PHONY: check-all
+check-all: $(check_PROGRAMS)
+	$(MAKE) $(AM_MAKEFLAGS) check TESTS="$(mplapack_mpfr_test_PROGRAMS)"
+
+mplapack_mpfr_test_PROGRAMS = \
+Cgelq2.test_mpfr \
+Cgeqr2.test_mpfr \
+Cgeqrf.test_mpfr \
+Cgesv.test_mpfr \
+Cgetf2.test_mpfr \
+Cgetrf.test_mpfr \
+Cgetri.test_mpfr \
+Cgetrs.test_mpfr \
+Cheev.test_mpfr \
+Chetd2.test_mpfr \
+Chetrd.test_mpfr \
+Clacgv.test_mpfr \
+Clacrm.test_mpfr \
+Clacrt.test_mpfr \
+Cladiv.test_mpfr \
+Claesy.test_mpfr \
+Claev2.test_mpfr \
+Clahef.test_mpfr \
+Clanhe.test_mpfr \
+Clanht.test_mpfr \
+Clansy.test_mpfr \
+Clarfb.test_mpfr \
+Clarfg.test_mpfr \
+Clarf.test_mpfr \
+Clarft.test_mpfr \
+Clartg.test_mpfr \
+Clascl.test_mpfr \
+Claset.test_mpfr \
+Clasr.test_mpfr \
+Classq.test_mpfr \
+Claswp.test_mpfr \
+Clasyf.test_mpfr \
+Clatrd.test_mpfr \
+Cpotf2.test_mpfr \
+Crot.test_mpfr \
+Cspmv.test_mpfr \
+Cspr.test_mpfr \
+Csteqr.test_mpfr \
+Csymv.test_mpfr \
+Csyr.test_mpfr \
+Ctrti2.test_mpfr \
+Ctrtri.test_mpfr \
+Ctrtrs.test_mpfr \
+Cung2l.test_mpfr \
+Cung2r.test_mpfr \
+Cungql.test_mpfr \
+Cungqr.test_mpfr \
+Cungtr.test_mpfr \
+Cunmqr.test_mpfr \
+iCmax1.test_mpfr \
+iMlaenv.test_mpfr \
+Mlsamen.test_mpfr \
+Mutils.test_mpfr \
+RCsum1.test_mpfr \
+Rgecon.test_mpfr \
+Rgeequ.test_mpfr \
+Rgeqlf.test_mpfr \
+Rgesv.test_mpfr \
+Rgetf2.test_mpfr \
+Rgetrf.test_mpfr \
+Rgetri.test_mpfr \
+Rgetrs.test_mpfr \
+Rladiv.test_mpfr \
+Rlae2.test_mpfr \
+Rlaev2.test_mpfr \
+Rlamch.test_mpfr \
+Rlange.test_mpfr \
+Rlanst.test_mpfr \
+Rlansy.test_mpfr \
+Rlapy2.test_mpfr \
+Rlapy3.test_mpfr \
+Rlarfb.test_mpfr \
+Rlarfg.test_mpfr \
+Rlarf.test_mpfr \
+Rlarft.test_mpfr \
+Rlartg.test_mpfr \
+Rlaruv.test_mpfr \
+Rlascl.test_mpfr \
+Rlaset.test_mpfr \
+Rlasr.test_mpfr \
+Rlasrt.test_mpfr \
+Rlassq.test_mpfr \
+Rlaswp.test_mpfr \
+Rlasyf.test_mpfr \
+Rlatrd.test_mpfr \
+Rlatrs.test_mpfr \
+Rlauu2.test_mpfr \
+Rlauum.test_mpfr \
+Rnaninf.test_mpfr \
+Rorg2l.test_mpfr \
+Rorg2r.test_mpfr \
+Rorgql.test_mpfr \
+Rorgqr.test_mpfr \
+Rorgtr.test_mpfr \
+Rpocon.test_mpfr \
+Rposv.test_mpfr \
+Rpotf2.test_mpfr \
+Rpotri.test_mpfr \
+Rpotrs.test_mpfr \
+Rsteqr.test_mpfr \
+Rsterf.test_mpfr \
+Rsyev.test_mpfr \
+Rsytd2.test_mpfr \
+Rsytrd.test_mpfr \
+Rtrti2.test_mpfr \
+Rtrtri.test_mpfr \
+Rtrtrs.test_mpfr 
+
+
+mplapack_mpfr_testdir = $(prefix)/lib/$(target)/mplapack/test/compare/mpfr
+
+install-data-hook:
+if IS_MACOS
+	bash $(top_srcdir)/misc/fix_dylib_macOS.sh $(mplapack_mpfr_testdir) $(prefix)
+endif
+
+mplibs=-L$(MPC_LIBDIR) -L$(MPFR_LIBDIR) -L$(GMP_LIBDIR) -lmpc -lmpfr -lgmpxx -lgmp
+refblas=-L$(top_builddir)/external/i/LAPACK/lib -lblas $(FCLIBS)
+reflapack=-L$(top_builddir)/external/i/LAPACK/lib -llapack $(FCLIBS)
+
+test_cxxflags = $(OPENMP_CXXFLAGS) -I$(top_srcdir)/include -I$(GMP_INCLUDEDIR) -I$(MPFR_INCLUDEDIR) -I$(MPC_INCLUDEDIR) -I$(top_srcdir)/mpfrc++ -D___MPLAPACK_BUILD_WITH_MPFR___ -D___MPLAPACK_INTERNAL___
+AM_FFLAGS = -x f77-cpp-input -g
+
+test_srcdepends = ../../../../mpblas/test/common/xerbla.cpp ../../../../mpblas/test/common/mplapack.test.cpp
+
+if IS_MACOS
+mplibs+=-Wl,-flat_namespace,-undefined,dynamic_lookup
+endif
+
+if IS_MINGW
+$(check_PROGRAMS): libmxerbla_override.la
+lib_LTLIBRARIES = libmxerbla_override.la
+libmxerbla_override_la_CPPFLAGS = -I$(top_srcdir)/include -D___MPLAPACK_BUILD_WITH_MPFR___
+libmxerbla_override_la_SOURCES = ../../../../mpblas/test/common/Mxerbla.override.cpp
+libmxerbla_override_la_LDFLAGS = -no-undefined
+
+test_libdepends = $(mplibs) $(reflapack) $(refblas) -Wl,--allow-multiple-definition
+libdepends = -Wl,--allow-multiple-definition -Wl,--whole-archive,.libs/libmxerbla_override.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_mpfr.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_mpfr.a,--no-whole-archive
+else
+test_srcdepends += ../../../../mpblas/test/common/Mxerbla.override.cpp
+test_libdepends = $(mplibs) $(reflapack) $(refblas)
+libdepends = -L$(top_builddir)/mplapack/reference -lmplapack_mpfr -L$(top_builddir)/mpblas/reference -lmpblas_mpfr
+endif
+
+Mutils_test_mpfr_SOURCES  = ../common/Mutils.test.cpp $(test_srcdepends) ../common/ilaenv.cpp
+Mutils_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mutils_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cgelq2_test_mpfr_SOURCES  = ../common/Cgelq2.test.cpp $(test_srcdepends)
+Cgelq2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgelq2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cgeqr2_test_mpfr_SOURCES  = ../common/Cgeqr2.test.cpp $(test_srcdepends)
+Cgeqr2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqr2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cgeqrf_test_mpfr_SOURCES  = ../common/Cgeqrf.test.cpp $(test_srcdepends)
+Cgeqrf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqrf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cgesv_test_mpfr_SOURCES  = ../common/Cgesv.test.cpp $(test_srcdepends)
+Cgesv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgesv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cgetf2_test_mpfr_SOURCES  = ../common/Cgetf2.test.cpp $(test_srcdepends)
+Cgetf2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetf2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cgetrf_test_mpfr_SOURCES  = ../common/Cgetrf.test.cpp $(test_srcdepends)
+Cgetrf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cgetri_test_mpfr_SOURCES  = ../common/Cgetri.test.cpp $(test_srcdepends)
+Cgetri_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetri_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cgetrs_test_mpfr_SOURCES  = ../common/Cgetrs.test.cpp $(test_srcdepends)
+Cgetrs_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrs_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cheev_test_mpfr_SOURCES  = ../common/Cheev.test.cpp $(test_srcdepends)
+Cheev_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cheev_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Chetd2_test_mpfr_SOURCES  = ../common/Chetd2.test.cpp $(test_srcdepends)
+Chetd2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetd2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Chetrd_test_mpfr_SOURCES  = ../common/Chetrd.test.cpp $(test_srcdepends)
+Chetrd_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetrd_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clacgv_test_mpfr_SOURCES  = ../common/Clacgv.test.cpp $(test_srcdepends)
+Clacgv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacgv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clacrm_test_mpfr_SOURCES  = ../common/Clacrm.test.cpp $(test_srcdepends)
+Clacrm_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrm_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clacrt_test_mpfr_SOURCES  = ../common/Clacrt.test.cpp $(test_srcdepends)
+Clacrt_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrt_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cladiv_test_mpfr_SOURCES  = ../common/Cladiv.test.cpp $(test_srcdepends)
+Cladiv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cladiv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Claesy_test_mpfr_SOURCES  = ../common/Claesy.test.cpp $(test_srcdepends)
+Claesy_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claesy_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Claev2_test_mpfr_SOURCES  = ../common/Claev2.test.cpp $(test_srcdepends)
+Claev2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claev2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clahef_test_mpfr_SOURCES  = ../common/Clahef.test.cpp $(test_srcdepends)
+Clahef_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clahef_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clanhe_test_mpfr_SOURCES  = ../common/Clanhe.test.cpp $(test_srcdepends)
+Clanhe_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanhe_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clanht_test_mpfr_SOURCES  = ../common/Clanht.test.cpp $(test_srcdepends)
+Clanht_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanht_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clansy_test_mpfr_SOURCES  = ../common/Clansy.test.cpp $(test_srcdepends)
+Clansy_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clansy_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clarfb_test_mpfr_SOURCES  = ../common/Clarfb.test.cpp $(test_srcdepends)
+Clarfb_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfb_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clarfg_test_mpfr_SOURCES  = ../common/Clarfg.test.cpp $(test_srcdepends)
+Clarfg_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfg_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clarf_test_mpfr_SOURCES  = ../common/Clarf.test.cpp $(test_srcdepends)
+Clarf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clarft_test_mpfr_SOURCES  = ../common/Clarft.test.cpp $(test_srcdepends)
+Clarft_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarft_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clartg_test_mpfr_SOURCES  = ../common/Clartg.test.cpp $(test_srcdepends)
+Clartg_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clartg_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clascl_test_mpfr_SOURCES  = ../common/Clascl.test.cpp $(test_srcdepends)
+Clascl_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clascl_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Claset_test_mpfr_SOURCES  = ../common/Claset.test.cpp $(test_srcdepends)
+Claset_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claset_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clasr_test_mpfr_SOURCES  = ../common/Clasr.test.cpp $(test_srcdepends)
+Clasr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Classq_test_mpfr_SOURCES  = ../common/Classq.test.cpp $(test_srcdepends)
+Classq_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Classq_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Claswp_test_mpfr_SOURCES  = ../common/Claswp.test.cpp $(test_srcdepends)
+Claswp_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claswp_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clasyf_test_mpfr_SOURCES  = ../common/Clasyf.test.cpp $(test_srcdepends)
+Clasyf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasyf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Clatrd_test_mpfr_SOURCES  = ../common/Clatrd.test.cpp $(test_srcdepends)
+Clatrd_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clatrd_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cpotf2_test_mpfr_SOURCES  = ../common/Cpotf2.test.cpp $(test_srcdepends)
+Cpotf2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cpotf2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Crot_test_mpfr_SOURCES  = ../common/Crot.test.cpp $(test_srcdepends)
+Crot_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Crot_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cspmv_test_mpfr_SOURCES  = ../common/Cspmv.test.cpp $(test_srcdepends)
+Cspmv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspmv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cspr_test_mpfr_SOURCES  = ../common/Cspr.test.cpp $(test_srcdepends)
+Cspr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Csteqr_test_mpfr_SOURCES  = ../common/Csteqr.test.cpp $(test_srcdepends)
+Csteqr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csteqr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Csymv_test_mpfr_SOURCES  = ../common/Csymv.test.cpp $(test_srcdepends)
+Csymv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csymv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Csyr_test_mpfr_SOURCES  = ../common/Csyr.test.cpp $(test_srcdepends)
+Csyr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csyr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Ctrti2_test_mpfr_SOURCES  = ../common/Ctrti2.test.cpp $(test_srcdepends)
+Ctrti2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrti2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Ctrtri_test_mpfr_SOURCES  = ../common/Ctrtri.test.cpp $(test_srcdepends)
+Ctrtri_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtri_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Ctrtrs_test_mpfr_SOURCES  = ../common/Ctrtrs.test.cpp $(test_srcdepends)
+Ctrtrs_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtrs_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cung2l_test_mpfr_SOURCES  = ../common/Cung2l.test.cpp $(test_srcdepends)
+Cung2l_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2l_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cung2r_test_mpfr_SOURCES  = ../common/Cung2r.test.cpp $(test_srcdepends)
+Cung2r_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2r_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cungql_test_mpfr_SOURCES  = ../common/Cungql.test.cpp $(test_srcdepends)
+Cungql_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungql_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cungqr_test_mpfr_SOURCES  = ../common/Cungqr.test.cpp $(test_srcdepends)
+Cungqr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungqr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cungtr_test_mpfr_SOURCES  = ../common/Cungtr.test.cpp $(test_srcdepends)
+Cungtr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungtr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Cunmqr_test_mpfr_SOURCES  = ../common/Cunmqr.test.cpp $(test_srcdepends)
+Cunmqr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cunmqr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+iCmax1_test_mpfr_SOURCES  = ../common/iCmax1.test.cpp $(test_srcdepends)
+iCmax1_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+iCmax1_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+iMlaenv_test_mpfr_SOURCES  = ../common/iMlaenv.test.cpp $(test_srcdepends)
+iMlaenv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+iMlaenv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Mlsamen_test_mpfr_SOURCES  = ../common/Mlsamen.test.cpp $(test_srcdepends)
+Mlsamen_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mlsamen_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+RCsum1_test_mpfr_SOURCES  = ../common/RCsum1.test.cpp $(test_srcdepends)
+RCsum1_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+RCsum1_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rgecon_test_mpfr_SOURCES  = ../common/Rgecon.test.cpp $(test_srcdepends)
+Rgecon_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgecon_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rgeequ_test_mpfr_SOURCES  = ../common/Rgeequ.test.cpp $(test_srcdepends)
+Rgeequ_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeequ_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rgeqlf_test_mpfr_SOURCES  = ../common/Rgeqlf.test.cpp $(test_srcdepends)
+Rgeqlf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeqlf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rgesv_test_mpfr_SOURCES  = ../common/Rgesv.test.cpp $(test_srcdepends)
+Rgesv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgesv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rgetf2_test_mpfr_SOURCES  = ../common/Rgetf2.test.cpp $(test_srcdepends)
+Rgetf2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetf2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rgetrf_test_mpfr_SOURCES  = ../common/Rgetrf.test.cpp $(test_srcdepends)
+Rgetrf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rgetri_test_mpfr_SOURCES  = ../common/Rgetri.test.cpp $(test_srcdepends)
+Rgetri_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetri_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rgetrs_test_mpfr_SOURCES  = ../common/Rgetrs.test.cpp $(test_srcdepends)
+Rgetrs_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrs_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rladiv_test_mpfr_SOURCES  = ../common/Rladiv.test.cpp $(test_srcdepends)
+Rladiv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rladiv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlae2_test_mpfr_SOURCES  = ../common/Rlae2.test.cpp $(test_srcdepends)
+Rlae2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlae2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlaev2_test_mpfr_SOURCES  = ../common/Rlaev2.test.cpp $(test_srcdepends)
+Rlaev2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaev2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlamch_test_mpfr_SOURCES  = ../common/Rlamch.test.cpp $(test_srcdepends)
+Rlamch_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlamch_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlange_test_mpfr_SOURCES  = ../common/Rlange.test.cpp $(test_srcdepends)
+Rlange_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlange_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlanst_test_mpfr_SOURCES  = ../common/Rlanst.test.cpp $(test_srcdepends)
+Rlanst_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlanst_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlansy_test_mpfr_SOURCES  = ../common/Rlansy.test.cpp $(test_srcdepends)
+Rlansy_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlansy_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlapy2_test_mpfr_SOURCES  = ../common/Rlapy2.test.cpp $(test_srcdepends)
+Rlapy2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlapy3_test_mpfr_SOURCES  = ../common/Rlapy3.test.cpp $(test_srcdepends)
+Rlapy3_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy3_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlarfb_test_mpfr_SOURCES  = ../common/Rlarfb.test.cpp $(test_srcdepends)
+Rlarfb_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfb_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlarfg_test_mpfr_SOURCES  = ../common/Rlarfg.test.cpp $(test_srcdepends)
+Rlarfg_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfg_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlarf_test_mpfr_SOURCES  = ../common/Rlarf.test.cpp $(test_srcdepends)
+Rlarf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlarft_test_mpfr_SOURCES  = ../common/Rlarft.test.cpp $(test_srcdepends)
+Rlarft_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarft_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlartg_test_mpfr_SOURCES  = ../common/Rlartg.test.cpp $(test_srcdepends)
+Rlartg_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlartg_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlaruv_test_mpfr_SOURCES  = ../common/Rlaruv.test.cpp $(test_srcdepends)
+Rlaruv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaruv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlascl_test_mpfr_SOURCES  = ../common/Rlascl.test.cpp $(test_srcdepends)
+Rlascl_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlascl_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlaset_test_mpfr_SOURCES  = ../common/Rlaset.test.cpp $(test_srcdepends)
+Rlaset_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaset_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlasr_test_mpfr_SOURCES  = ../common/Rlasr.test.cpp $(test_srcdepends)
+Rlasr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlasrt_test_mpfr_SOURCES  = ../common/Rlasrt.test.cpp $(test_srcdepends)
+Rlasrt_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasrt_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlassq_test_mpfr_SOURCES  = ../common/Rlassq.test.cpp $(test_srcdepends)
+Rlassq_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlassq_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlaswp_test_mpfr_SOURCES  = ../common/Rlaswp.test.cpp $(test_srcdepends)
+Rlaswp_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaswp_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlasyf_test_mpfr_SOURCES  = ../common/Rlasyf.test.cpp $(test_srcdepends)
+Rlasyf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasyf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlatrd_test_mpfr_SOURCES  = ../common/Rlatrd.test.cpp $(test_srcdepends)
+Rlatrd_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrd_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlatrs_test_mpfr_SOURCES  = ../common/Rlatrs.test.cpp $(test_srcdepends)
+Rlatrs_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrs_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlauu2_test_mpfr_SOURCES  = ../common/Rlauu2.test.cpp $(test_srcdepends)
+Rlauu2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauu2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rlauum_test_mpfr_SOURCES  = ../common/Rlauum.test.cpp $(test_srcdepends)
+Rlauum_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauum_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rnaninf_test_mpfr_SOURCES  = ../common/Rnaninf.test.cpp $(test_srcdepends)
+Rnaninf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rnaninf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rorg2l_test_mpfr_SOURCES  = ../common/Rorg2l.test.cpp $(test_srcdepends)
+Rorg2l_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2l_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rorg2r_test_mpfr_SOURCES  = ../common/Rorg2r.test.cpp $(test_srcdepends)
+Rorg2r_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2r_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rorgql_test_mpfr_SOURCES  = ../common/Rorgql.test.cpp $(test_srcdepends)
+Rorgql_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgql_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rorgqr_test_mpfr_SOURCES  = ../common/Rorgqr.test.cpp $(test_srcdepends)
+Rorgqr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgqr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rorgtr_test_mpfr_SOURCES  = ../common/Rorgtr.test.cpp $(test_srcdepends)
+Rorgtr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgtr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rpocon_test_mpfr_SOURCES  = ../common/Rpocon.test.cpp $(test_srcdepends)
+Rpocon_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpocon_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rposv_test_mpfr_SOURCES  = ../common/Rposv.test.cpp $(test_srcdepends)
+Rposv_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rposv_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rpotf2_test_mpfr_SOURCES  = ../common/Rpotf2.test.cpp $(test_srcdepends)
+Rpotf2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotf2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rpotri_test_mpfr_SOURCES  = ../common/Rpotri.test.cpp $(test_srcdepends)
+Rpotri_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotri_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rpotrs_test_mpfr_SOURCES  = ../common/Rpotrs.test.cpp $(test_srcdepends)
+Rpotrs_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotrs_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rsteqr_test_mpfr_SOURCES  = ../common/Rsteqr.test.cpp $(test_srcdepends)
+Rsteqr_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsteqr_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rsterf_test_mpfr_SOURCES  = ../common/Rsterf.test.cpp $(test_srcdepends)
+Rsterf_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsterf_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rsyev_test_mpfr_SOURCES  = ../common/Rsyev.test.cpp $(test_srcdepends)
+Rsyev_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsyev_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rsytd2_test_mpfr_SOURCES  = ../common/Rsytd2.test.cpp $(test_srcdepends)
+Rsytd2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytd2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rsytrd_test_mpfr_SOURCES  = ../common/Rsytrd.test.cpp $(test_srcdepends)
+Rsytrd_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytrd_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rtrti2_test_mpfr_SOURCES  = ../common/Rtrti2.test.cpp $(test_srcdepends)
+Rtrti2_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrti2_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rtrtri_test_mpfr_SOURCES  = ../common/Rtrtri.test.cpp $(test_srcdepends)
+Rtrtri_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtri_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+Rtrtrs_test_mpfr_SOURCES  = ../common/Rtrtrs.test.cpp $(test_srcdepends)
+Rtrtrs_test_mpfr_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtrs_test_mpfr_CXXFLAGS = $(test_cxxflags)
+
+
+

--- a/mplapack/test/compare/qd/Makefile.am
+++ b/mplapack/test/compare/qd/Makefile.am
@@ -1,0 +1,615 @@
+check_PROGRAMS = $(mplapack_qd_test_PROGRAMS)
+TESTS = run_Rlaruv_test.sh run_Rlamch_test.sh
+CLEANFILES = run_Rlaruv_test.sh run_Rlamch_test.sh Rlaruv.txt Rlamch.txt
+
+TEST_EXTENSIONS = .sh
+SH_LOG_COMPILER = $(SHELL)
+
+AM_TESTS_ENVIRONMENT = \
+    LOG_COMPILER='$(LOG_COMPILER)'; export LOG_COMPILER; \
+    EXEEXT='$(EXEEXT)'; export EXEEXT; \
+    srcdir='$(srcdir)'; export srcdir;
+
+run_Rlaruv_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo 'NUM_DIFF_PY="$(top_srcdir)/misc/num_diff.py"' >> $@
+	@echo '$${LOG_COMPILER} ./Rlaruv.test_qd$${EXEEXT} || true' >> $@
+	@echo 'if python3 "$${NUM_DIFF_PY}" "$${srcdir}/Rlaruv_reference.txt" Rlaruv.txt --tol 1e-60; then' >> $@
+	@echo '  echo "PASS: Rlaruv"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlaruv"; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+run_Rlamch_test.sh: Makefile
+	@echo '#!/bin/sh' > $@
+	@echo 'NUM_DIFF_PY="$(top_srcdir)/misc/num_diff.py"' >> $@
+	@echo '$${LOG_COMPILER} ./Rlamch.test_qd$${EXEEXT} || true' >> $@
+	@echo 'if python3 "$${NUM_DIFF_PY}" "$${srcdir}/Rlamch_reference.txt" Rlamch.txt --tol 1e-60; then' >> $@
+	@echo '  echo "PASS: Rlamch"; exit 0' >> $@
+	@echo 'else' >> $@
+	@echo '  echo "FAIL: Rlamch"; exit 1' >> $@
+	@echo 'fi' >> $@
+	@chmod +x $@
+
+EXTRA_DIST = Rlaruv_reference.txt Rlamch_reference.txt
+
+.PHONY: check-all
+check-all: $(check_PROGRAMS)
+	$(MAKE) $(AM_MAKEFLAGS) check TESTS="$(mplapack_qd_test_PROGRAMS)"
+
+mplapack_qd_test_PROGRAMS = \
+Cgelq2.test_qd \
+Cgeqr2.test_qd \
+Cgeqrf.test_qd \
+Cgesv.test_qd \
+Cgetf2.test_qd \
+Cgetrf.test_qd \
+Cgetri.test_qd \
+Cgetrs.test_qd \
+Cheev.test_qd \
+Chetd2.test_qd \
+Chetrd.test_qd \
+Clacgv.test_qd \
+Clacrm.test_qd \
+Clacrt.test_qd \
+Cladiv.test_qd \
+Claesy.test_qd \
+Claev2.test_qd \
+Clahef.test_qd \
+Clanhe.test_qd \
+Clanht.test_qd \
+Clansy.test_qd \
+Clarfb.test_qd \
+Clarfg.test_qd \
+Clarf.test_qd \
+Clarft.test_qd \
+Clartg.test_qd \
+Clascl.test_qd \
+Claset.test_qd \
+Clasr.test_qd \
+Classq.test_qd \
+Claswp.test_qd \
+Clasyf.test_qd \
+Clatrd.test_qd \
+Cpotf2.test_qd \
+Crot.test_qd \
+Cspmv.test_qd \
+Cspr.test_qd \
+Csteqr.test_qd \
+Csymv.test_qd \
+Csyr.test_qd \
+Ctrti2.test_qd \
+Ctrtri.test_qd \
+Ctrtrs.test_qd \
+Cung2l.test_qd \
+Cung2r.test_qd \
+Cungql.test_qd \
+Cungqr.test_qd \
+Cungtr.test_qd \
+Cunmqr.test_qd \
+iCmax1.test_qd \
+iMlaenv.test_qd \
+Mlsamen.test_qd \
+Mutils.test_qd \
+RCsum1.test_qd \
+Rgecon.test_qd \
+Rgeequ.test_qd \
+Rgeqlf.test_qd \
+Rgesv.test_qd \
+Rgetf2.test_qd \
+Rgetrf.test_qd \
+Rgetri.test_qd \
+Rgetrs.test_qd \
+Rladiv.test_qd \
+Rlae2.test_qd \
+Rlaev2.test_qd \
+Rlamch.test_qd \
+Rlange.test_qd \
+Rlanst.test_qd \
+Rlansy.test_qd \
+Rlapy2.test_qd \
+Rlapy3.test_qd \
+Rlarfb.test_qd \
+Rlarfg.test_qd \
+Rlarf.test_qd \
+Rlarft.test_qd \
+Rlartg.test_qd \
+Rlaruv.test_qd \
+Rlascl.test_qd \
+Rlaset.test_qd \
+Rlasr.test_qd \
+Rlasrt.test_qd \
+Rlassq.test_qd \
+Rlaswp.test_qd \
+Rlasyf.test_qd \
+Rlatrd.test_qd \
+Rlatrs.test_qd \
+Rlauu2.test_qd \
+Rlauum.test_qd \
+Rnaninf.test_qd \
+Rorg2l.test_qd \
+Rorg2r.test_qd \
+Rorgql.test_qd \
+Rorgqr.test_qd \
+Rorgtr.test_qd \
+Rpocon.test_qd \
+Rposv.test_qd \
+Rpotf2.test_qd \
+Rpotri.test_qd \
+Rpotrs.test_qd \
+Rsteqr.test_qd \
+Rsterf.test_qd \
+Rsyev.test_qd \
+Rsytd2.test_qd \
+Rsytrd.test_qd \
+Rtrti2.test_qd \
+Rtrtri.test_qd \
+Rtrtrs.test_qd 
+
+
+mplapack_qd_testdir = $(prefix)/lib/$(target)/mplapack/test/compare/qd
+
+install-data-hook:
+if IS_MACOS
+	bash $(top_srcdir)/misc/fix_dylib_macOS.sh $(mplapack_qd_testdir) $(prefix)
+endif
+
+mplibs=-L$(MPC_LIBDIR) -L$(MPFR_LIBDIR) -L$(QD_LIBDIR) -lmpc -lmpfr -lgmpxx -lgmp -lqd
+refblas=-L$(top_builddir)/external/i/LAPACK/lib -lblas $(FCLIBS)
+reflapack=-L$(top_builddir)/external/i/LAPACK/lib -llapack $(FCLIBS)
+
+test_cxxflags = $(OPENMP_CXXFLAGS) -I$(top_srcdir)/include -I$(GMP_INCLUDEDIR) -I$(MPFR_INCLUDEDIR) -I$(MPC_INCLUDEDIR) -I$(QD_INCLUDEDIR) -I$(top_srcdir)/mpfrc++ -D___MPLAPACK_BUILD_WITH_QD___ -D___MPLAPACK_INTERNAL___
+AM_FFLAGS = -x f77-cpp-input -g
+
+test_srcdepends = ../../../../mpblas/test/common/xerbla.cpp ../../../../mpblas/test/common/mplapack.test.cpp
+
+if IS_MACOS
+mplibs+=-Wl,-flat_namespace,-undefined,dynamic_lookup
+endif
+
+if IS_MINGW
+$(check_PROGRAMS): libmxerbla_override.la
+lib_LTLIBRARIES = libmxerbla_override.la
+libmxerbla_override_la_CPPFLAGS = -I$(top_srcdir)/include -D___MPLAPACK_BUILD_WITH_QD___
+libmxerbla_override_la_SOURCES = ../../../../mpblas/test/common/Mxerbla.override.cpp
+libmxerbla_override_la_LDFLAGS = -no-undefined
+
+test_libdepends = $(mplibs) $(reflapack) $(refblas) -Wl,--allow-multiple-definition
+libdepends = -Wl,--allow-multiple-definition -Wl,--whole-archive,.libs/libmxerbla_override.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_qd.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_qd.a,$(top_builddir)/mplapack/reference/.libs/libmplapack_mpfr.a,$(top_builddir)/mpblas/reference/.libs/libmpblas_mpfr.a,--no-whole-archive
+else
+test_srcdepends += ../../../../mpblas/test/common/Mxerbla.override.cpp
+test_libdepends = $(mplibs) $(reflapack) $(refblas)
+libdepends = -L$(top_builddir)/mplapack/reference -lmplapack_qd -lmplapack_mpfr -L$(top_builddir)/mpblas/reference -lmpblas_qd -lmpblas_mpfr
+endif
+
+Mutils_test_qd_SOURCES  = ../common/Mutils.test.cpp $(test_srcdepends) ../common/ilaenv.cpp
+Mutils_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mutils_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cgelq2_test_qd_SOURCES  = ../common/Cgelq2.test.cpp $(test_srcdepends)
+Cgelq2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgelq2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cgeqr2_test_qd_SOURCES  = ../common/Cgeqr2.test.cpp $(test_srcdepends)
+Cgeqr2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqr2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cgeqrf_test_qd_SOURCES  = ../common/Cgeqrf.test.cpp $(test_srcdepends)
+Cgeqrf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgeqrf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cgesv_test_qd_SOURCES  = ../common/Cgesv.test.cpp $(test_srcdepends)
+Cgesv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgesv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cgetf2_test_qd_SOURCES  = ../common/Cgetf2.test.cpp $(test_srcdepends)
+Cgetf2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetf2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cgetrf_test_qd_SOURCES  = ../common/Cgetrf.test.cpp $(test_srcdepends)
+Cgetrf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cgetri_test_qd_SOURCES  = ../common/Cgetri.test.cpp $(test_srcdepends)
+Cgetri_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetri_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cgetrs_test_qd_SOURCES  = ../common/Cgetrs.test.cpp $(test_srcdepends)
+Cgetrs_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cgetrs_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cheev_test_qd_SOURCES  = ../common/Cheev.test.cpp $(test_srcdepends)
+Cheev_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cheev_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Chetd2_test_qd_SOURCES  = ../common/Chetd2.test.cpp $(test_srcdepends)
+Chetd2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetd2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Chetrd_test_qd_SOURCES  = ../common/Chetrd.test.cpp $(test_srcdepends)
+Chetrd_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Chetrd_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clacgv_test_qd_SOURCES  = ../common/Clacgv.test.cpp $(test_srcdepends)
+Clacgv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacgv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clacrm_test_qd_SOURCES  = ../common/Clacrm.test.cpp $(test_srcdepends)
+Clacrm_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrm_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clacrt_test_qd_SOURCES  = ../common/Clacrt.test.cpp $(test_srcdepends)
+Clacrt_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clacrt_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cladiv_test_qd_SOURCES  = ../common/Cladiv.test.cpp $(test_srcdepends)
+Cladiv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cladiv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Claesy_test_qd_SOURCES  = ../common/Claesy.test.cpp $(test_srcdepends)
+Claesy_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claesy_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Claev2_test_qd_SOURCES  = ../common/Claev2.test.cpp $(test_srcdepends)
+Claev2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claev2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clahef_test_qd_SOURCES  = ../common/Clahef.test.cpp $(test_srcdepends)
+Clahef_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clahef_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clanhe_test_qd_SOURCES  = ../common/Clanhe.test.cpp $(test_srcdepends)
+Clanhe_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanhe_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clanht_test_qd_SOURCES  = ../common/Clanht.test.cpp $(test_srcdepends)
+Clanht_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clanht_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clansy_test_qd_SOURCES  = ../common/Clansy.test.cpp $(test_srcdepends)
+Clansy_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clansy_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clarfb_test_qd_SOURCES  = ../common/Clarfb.test.cpp $(test_srcdepends)
+Clarfb_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfb_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clarfg_test_qd_SOURCES  = ../common/Clarfg.test.cpp $(test_srcdepends)
+Clarfg_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarfg_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clarf_test_qd_SOURCES  = ../common/Clarf.test.cpp $(test_srcdepends)
+Clarf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clarft_test_qd_SOURCES  = ../common/Clarft.test.cpp $(test_srcdepends)
+Clarft_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clarft_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clartg_test_qd_SOURCES  = ../common/Clartg.test.cpp $(test_srcdepends)
+Clartg_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clartg_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clascl_test_qd_SOURCES  = ../common/Clascl.test.cpp $(test_srcdepends)
+Clascl_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clascl_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Claset_test_qd_SOURCES  = ../common/Claset.test.cpp $(test_srcdepends)
+Claset_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claset_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clasr_test_qd_SOURCES  = ../common/Clasr.test.cpp $(test_srcdepends)
+Clasr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Classq_test_qd_SOURCES  = ../common/Classq.test.cpp $(test_srcdepends)
+Classq_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Classq_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Claswp_test_qd_SOURCES  = ../common/Claswp.test.cpp $(test_srcdepends)
+Claswp_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Claswp_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clasyf_test_qd_SOURCES  = ../common/Clasyf.test.cpp $(test_srcdepends)
+Clasyf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clasyf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Clatrd_test_qd_SOURCES  = ../common/Clatrd.test.cpp $(test_srcdepends)
+Clatrd_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Clatrd_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cpotf2_test_qd_SOURCES  = ../common/Cpotf2.test.cpp $(test_srcdepends)
+Cpotf2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cpotf2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Crot_test_qd_SOURCES  = ../common/Crot.test.cpp $(test_srcdepends)
+Crot_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Crot_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cspmv_test_qd_SOURCES  = ../common/Cspmv.test.cpp $(test_srcdepends)
+Cspmv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspmv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cspr_test_qd_SOURCES  = ../common/Cspr.test.cpp $(test_srcdepends)
+Cspr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cspr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Csteqr_test_qd_SOURCES  = ../common/Csteqr.test.cpp $(test_srcdepends)
+Csteqr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csteqr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Csymv_test_qd_SOURCES  = ../common/Csymv.test.cpp $(test_srcdepends)
+Csymv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csymv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Csyr_test_qd_SOURCES  = ../common/Csyr.test.cpp $(test_srcdepends)
+Csyr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Csyr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Ctrti2_test_qd_SOURCES  = ../common/Ctrti2.test.cpp $(test_srcdepends)
+Ctrti2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrti2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Ctrtri_test_qd_SOURCES  = ../common/Ctrtri.test.cpp $(test_srcdepends)
+Ctrtri_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtri_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Ctrtrs_test_qd_SOURCES  = ../common/Ctrtrs.test.cpp $(test_srcdepends)
+Ctrtrs_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Ctrtrs_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cung2l_test_qd_SOURCES  = ../common/Cung2l.test.cpp $(test_srcdepends)
+Cung2l_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2l_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cung2r_test_qd_SOURCES  = ../common/Cung2r.test.cpp $(test_srcdepends)
+Cung2r_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cung2r_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cungql_test_qd_SOURCES  = ../common/Cungql.test.cpp $(test_srcdepends)
+Cungql_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungql_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cungqr_test_qd_SOURCES  = ../common/Cungqr.test.cpp $(test_srcdepends)
+Cungqr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungqr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cungtr_test_qd_SOURCES  = ../common/Cungtr.test.cpp $(test_srcdepends)
+Cungtr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cungtr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Cunmqr_test_qd_SOURCES  = ../common/Cunmqr.test.cpp $(test_srcdepends)
+Cunmqr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Cunmqr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+iCmax1_test_qd_SOURCES  = ../common/iCmax1.test.cpp $(test_srcdepends)
+iCmax1_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+iCmax1_test_qd_CXXFLAGS = $(test_cxxflags)
+
+iMlaenv_test_qd_SOURCES  = ../common/iMlaenv.test.cpp $(test_srcdepends)
+iMlaenv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+iMlaenv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Mlsamen_test_qd_SOURCES  = ../common/Mlsamen.test.cpp $(test_srcdepends)
+Mlsamen_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Mlsamen_test_qd_CXXFLAGS = $(test_cxxflags)
+
+RCsum1_test_qd_SOURCES  = ../common/RCsum1.test.cpp $(test_srcdepends)
+RCsum1_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+RCsum1_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rgecon_test_qd_SOURCES  = ../common/Rgecon.test.cpp $(test_srcdepends)
+Rgecon_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgecon_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rgeequ_test_qd_SOURCES  = ../common/Rgeequ.test.cpp $(test_srcdepends)
+Rgeequ_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeequ_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rgeqlf_test_qd_SOURCES  = ../common/Rgeqlf.test.cpp $(test_srcdepends)
+Rgeqlf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgeqlf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rgesv_test_qd_SOURCES  = ../common/Rgesv.test.cpp $(test_srcdepends)
+Rgesv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgesv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rgetf2_test_qd_SOURCES  = ../common/Rgetf2.test.cpp $(test_srcdepends)
+Rgetf2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetf2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rgetrf_test_qd_SOURCES  = ../common/Rgetrf.test.cpp $(test_srcdepends)
+Rgetrf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rgetri_test_qd_SOURCES  = ../common/Rgetri.test.cpp $(test_srcdepends)
+Rgetri_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetri_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rgetrs_test_qd_SOURCES  = ../common/Rgetrs.test.cpp $(test_srcdepends)
+Rgetrs_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rgetrs_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rladiv_test_qd_SOURCES  = ../common/Rladiv.test.cpp $(test_srcdepends)
+Rladiv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rladiv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlae2_test_qd_SOURCES  = ../common/Rlae2.test.cpp $(test_srcdepends)
+Rlae2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlae2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlaev2_test_qd_SOURCES  = ../common/Rlaev2.test.cpp $(test_srcdepends)
+Rlaev2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaev2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlamch_test_qd_SOURCES  = ../common/Rlamch.test.cpp $(test_srcdepends)
+Rlamch_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlamch_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlange_test_qd_SOURCES  = ../common/Rlange.test.cpp $(test_srcdepends)
+Rlange_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlange_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlanst_test_qd_SOURCES  = ../common/Rlanst.test.cpp $(test_srcdepends)
+Rlanst_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlanst_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlansy_test_qd_SOURCES  = ../common/Rlansy.test.cpp $(test_srcdepends)
+Rlansy_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlansy_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlapy2_test_qd_SOURCES  = ../common/Rlapy2.test.cpp $(test_srcdepends)
+Rlapy2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlapy3_test_qd_SOURCES  = ../common/Rlapy3.test.cpp $(test_srcdepends)
+Rlapy3_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlapy3_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlarfb_test_qd_SOURCES  = ../common/Rlarfb.test.cpp $(test_srcdepends)
+Rlarfb_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfb_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlarfg_test_qd_SOURCES  = ../common/Rlarfg.test.cpp $(test_srcdepends)
+Rlarfg_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarfg_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlarf_test_qd_SOURCES  = ../common/Rlarf.test.cpp $(test_srcdepends)
+Rlarf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlarft_test_qd_SOURCES  = ../common/Rlarft.test.cpp $(test_srcdepends)
+Rlarft_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlarft_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlartg_test_qd_SOURCES  = ../common/Rlartg.test.cpp $(test_srcdepends)
+Rlartg_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlartg_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlaruv_test_qd_SOURCES  = ../common/Rlaruv.test.cpp $(test_srcdepends)
+Rlaruv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaruv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlascl_test_qd_SOURCES  = ../common/Rlascl.test.cpp $(test_srcdepends)
+Rlascl_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlascl_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlaset_test_qd_SOURCES  = ../common/Rlaset.test.cpp $(test_srcdepends)
+Rlaset_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaset_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlasr_test_qd_SOURCES  = ../common/Rlasr.test.cpp $(test_srcdepends)
+Rlasr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlasrt_test_qd_SOURCES  = ../common/Rlasrt.test.cpp $(test_srcdepends)
+Rlasrt_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasrt_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlassq_test_qd_SOURCES  = ../common/Rlassq.test.cpp $(test_srcdepends)
+Rlassq_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlassq_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlaswp_test_qd_SOURCES  = ../common/Rlaswp.test.cpp $(test_srcdepends)
+Rlaswp_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlaswp_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlasyf_test_qd_SOURCES  = ../common/Rlasyf.test.cpp $(test_srcdepends)
+Rlasyf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlasyf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlatrd_test_qd_SOURCES  = ../common/Rlatrd.test.cpp $(test_srcdepends)
+Rlatrd_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrd_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlatrs_test_qd_SOURCES  = ../common/Rlatrs.test.cpp $(test_srcdepends)
+Rlatrs_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlatrs_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlauu2_test_qd_SOURCES  = ../common/Rlauu2.test.cpp $(test_srcdepends)
+Rlauu2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauu2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rlauum_test_qd_SOURCES  = ../common/Rlauum.test.cpp $(test_srcdepends)
+Rlauum_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rlauum_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rnaninf_test_qd_SOURCES  = ../common/Rnaninf.test.cpp $(test_srcdepends)
+Rnaninf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rnaninf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rorg2l_test_qd_SOURCES  = ../common/Rorg2l.test.cpp $(test_srcdepends)
+Rorg2l_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2l_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rorg2r_test_qd_SOURCES  = ../common/Rorg2r.test.cpp $(test_srcdepends)
+Rorg2r_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorg2r_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rorgql_test_qd_SOURCES  = ../common/Rorgql.test.cpp $(test_srcdepends)
+Rorgql_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgql_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rorgqr_test_qd_SOURCES  = ../common/Rorgqr.test.cpp $(test_srcdepends)
+Rorgqr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgqr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rorgtr_test_qd_SOURCES  = ../common/Rorgtr.test.cpp $(test_srcdepends)
+Rorgtr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rorgtr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rpocon_test_qd_SOURCES  = ../common/Rpocon.test.cpp $(test_srcdepends)
+Rpocon_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpocon_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rposv_test_qd_SOURCES  = ../common/Rposv.test.cpp $(test_srcdepends)
+Rposv_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rposv_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rpotf2_test_qd_SOURCES  = ../common/Rpotf2.test.cpp $(test_srcdepends)
+Rpotf2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotf2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rpotri_test_qd_SOURCES  = ../common/Rpotri.test.cpp $(test_srcdepends)
+Rpotri_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotri_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rpotrs_test_qd_SOURCES  = ../common/Rpotrs.test.cpp $(test_srcdepends)
+Rpotrs_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rpotrs_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rsteqr_test_qd_SOURCES  = ../common/Rsteqr.test.cpp $(test_srcdepends)
+Rsteqr_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsteqr_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rsterf_test_qd_SOURCES  = ../common/Rsterf.test.cpp $(test_srcdepends)
+Rsterf_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsterf_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rsyev_test_qd_SOURCES  = ../common/Rsyev.test.cpp $(test_srcdepends)
+Rsyev_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsyev_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rsytd2_test_qd_SOURCES  = ../common/Rsytd2.test.cpp $(test_srcdepends)
+Rsytd2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytd2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rsytrd_test_qd_SOURCES  = ../common/Rsytrd.test.cpp $(test_srcdepends)
+Rsytrd_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rsytrd_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rtrti2_test_qd_SOURCES  = ../common/Rtrti2.test.cpp $(test_srcdepends)
+Rtrti2_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrti2_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rtrtri_test_qd_SOURCES  = ../common/Rtrtri.test.cpp $(test_srcdepends)
+Rtrtri_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtri_test_qd_CXXFLAGS = $(test_cxxflags)
+
+Rtrtrs_test_qd_SOURCES  = ../common/Rtrtrs.test.cpp $(test_srcdepends)
+Rtrtrs_test_qd_LDFLAGS  = $(libdepends) $(test_libdepends)
+Rtrtrs_test_qd_CXXFLAGS = $(test_cxxflags)
+
+
+


### PR DESCRIPTION
Two build-system fixes hit on Fedora 44 with GCC 16 when building the binary128/binary80 backends from a git checkout.

## BUG 1 — fresh git checkout cannot be bootstrapped

In a clean clone, `autoreconf -fi` aborts:

```
configure.ac:2152: error: required file 'mplapack/test/compare/binary128/Makefile.in' not found
```

`configure.ac` lists `mplapack/test/compare/<backend>/Makefile` in `AC_CONFIG_FILES`, but those `Makefile.am` are **generated** by `mplapack/test/compare/gen.Makefile.am.sh` from the `Makefile.am.part` templates — a step only the developer `reconfig.*.sh` scripts run *before* `autoreconf`. They were never committed (unlike the committed `mpblas/test/<backend>/Makefile.am` siblings), so automake can't find the `Makefile.in` it needs and bootstrap fails. Only the release tarball, which ships them, worked.

**Fix:** generate and commit the seven `mplapack/test/compare/<backend>/Makefile.am`, and add the generator + `*.part` templates to `EXTRA_DIST` so a dist tarball can still regenerate them when new `common/*.test.cpp` cases are added.

## BUG 2 — conflicting `-std` flags; stale `gnu++11` wins

After configuring, the generated Makefiles could contain:

```
CXX = g++ -std=gnu++11 -std=gnu++17 -std=gnu++11
```

The trailing `-std=gnu++11` takes effect, so the C++14/17 features in `mplapack_utils_*.h` (`std::enable_if_t`, `std::is_same_v`, variadic fold expressions) fail with `'enable_if_t' in namespace 'std' does not name a template type`.

`AX_CXX_COMPILE_STDCXX([17])` only *appends* `-std=gnu++17` to `CXX`; it never removes a pre-existing `-std`. A stale `-std=gnu++11` arriving via the environment's `CXX` or `CXXFLAGS` (the latter lands after `CXX` on the command line) survives and, being last, overrides the required standard.

**Fix:** run `AC_PROG_CXX`, strip every `-std=*` from `CXX` and `CXXFLAGS` via the existing `MPLAPACK_STRIP_FLAG` helper, then let `AX_CXX_COMPILE_STDCXX` add the one required `-std=gnu++17`. Exactly one standard is now in effect and cannot be overridden by the environment. The now-redundant later `AC_PROG_CXX` is dropped.

## Verification (x86-64 Linux, GCC 16)

- `git clean -xfd && autoreconf -fi` → exit 0, `configure` produced.
- `./configure --enable-binary128=yes --enable-binary80=yes --enable-double=no --enable-gmp=no --enable-mpfr=no --enable-qd=no --enable-dd=no --enable-test=no --enable-benchmark=no --enable-examples=no && make -j` → **0 errors**.
- Exactly one effective `-std=gnu++17` in the Makefiles, even when configured with `CXX='g++ -std=gnu++11' CXXFLAGS='-std=gnu++11 -O2'`.
- Built `libmpblas_binary128.a`, `libmpblas_binary80.a`, `libmplapack_binary128.a`, `libmplapack_binary80.a` (incl. the `Rgemm` binary128 object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
